### PR TITLE
Improve bridge burner outbox validation

### DIFF
--- a/src/bridge/BridgeBurner.sol
+++ b/src/bridge/BridgeBurner.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.30;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IBridgeBurner} from "./interfaces/IBridgeBurner.sol";
 import {IOutbox} from "./interfaces/IOutbox.sol";
 import {Stablecoin} from "../Stablecoin.sol";
@@ -28,6 +29,7 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     error ZeroRecipient();
     error ZeroAmount();
     error SameChain();
+    error InvalidOutbox(address outbox);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -40,7 +42,7 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @param outbox_ Address of the Outbox contract used to send cross-chain messages.
     function initialize(address owner_, address stablecoin_, address outbox_) public initializer {
         require(stablecoin_ != address(0), ZeroAddress());
-        require(outbox_ != address(0), ZeroAddress());
+        _validateOutbox(outbox_);
         __Ownable_init(owner_);
         stablecoin = Stablecoin(stablecoin_);
         outbox = IOutbox(outbox_);
@@ -53,11 +55,27 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     }
 
     /// @notice Update the Outbox contract reference.
+    /// @dev Sensitive maintenance operation: should be performed during a paused window.
+    /// The target MUST advertise IOutbox via ERC-165; rejecting `address(0)` alone is
+    /// insufficient because a contract implementing `sendMessage(...)` without emitting
+    /// `MessageSent` would otherwise let `sendTo` burn tokens without producing a
+    /// verifiable bridge message.
     /// @param outbox_ Address of the new Outbox contract.
     function setOutbox(address outbox_) external onlyOwner {
-        require(outbox_ != address(0), ZeroAddress());
+        _validateOutbox(outbox_);
         outbox = IOutbox(outbox_);
         emit OutboxSet(outbox_);
+    }
+
+    /// @dev Reject zero address and any target that does not advertise `IOutbox`
+    /// via ERC-165. Catches reverts and non-introspectable contracts.
+    function _validateOutbox(address outbox_) internal view {
+        require(outbox_ != address(0), ZeroAddress());
+        try IERC165(outbox_).supportsInterface(type(IOutbox).interfaceId) returns (bool ok) {
+            require(ok, InvalidOutbox(outbox_));
+        } catch {
+            revert InvalidOutbox(outbox_);
+        }
     }
 
     /// @notice Update the stablecoin contract reference.

--- a/src/bridge/BridgeBurner.sol
+++ b/src/bridge/BridgeBurner.sol
@@ -67,10 +67,13 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
         emit OutboxSet(outbox_);
     }
 
-    /// @dev Reject zero address and any target that does not advertise `IOutbox`
-    /// via ERC-165. Catches reverts and non-introspectable contracts.
+    /// @dev Reject zero address, EOAs, and any target that does not advertise
+    /// `IOutbox` via ERC-165. The explicit `code.length` check routes EOAs through
+    /// `InvalidOutbox` rather than the lower-level "call to non-contract address"
+    /// revert solc emits for external calls into accounts with no code.
     function _validateOutbox(address outbox_) internal view {
         require(outbox_ != address(0), ZeroAddress());
+        require(outbox_.code.length > 0, InvalidOutbox(outbox_));
         try IERC165(outbox_).supportsInterface(type(IOutbox).interfaceId) returns (bool ok) {
             require(ok, InvalidOutbox(outbox_));
         } catch {

--- a/src/bridge/Outbox.sol
+++ b/src/bridge/Outbox.sol
@@ -5,6 +5,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IOutbox} from "./interfaces/IOutbox.sol";
 
 /// @title Outbox
@@ -26,6 +27,12 @@ contract Outbox is Initializable, Ownable2StepUpgradeable, PausableUpgradeable, 
     /// @inheritdoc IOutbox
     function sendMessage(uint256 dstChain, address dstRecipient, bytes calldata payload) external whenNotPaused {
         emit MessageSent(msg.sender, dstChain, dstRecipient, payload);
+    }
+
+    /// @notice ERC-165 marker so consumers (e.g. BridgeBurner) can verify they have
+    /// been pointed at a canonical Outbox before burning user tokens against it.
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IOutbox).interfaceId || interfaceId == type(IERC165).interfaceId;
     }
 
     /// @notice Pause the outbox, blocking all outbound messages.

--- a/test/bridge/BridgeBurner.t.sol
+++ b/test/bridge/BridgeBurner.t.sol
@@ -83,4 +83,68 @@ contract BridgeBurnerTest is BridgeTestBase {
         vm.expectRevert();
         bridge.bridgeBurner.setStablecoin(address(0x1111));
     }
+
+    // ─── Outbox validation (L-04 / #7) ────────────────────────────────
+
+    function test_SetOutboxRejectsZeroAddress() public {
+        vm.prank(ADMIN);
+        vm.expectRevert(BridgeBurner.ZeroAddress.selector);
+        bridge.bridgeBurner.setOutbox(address(0));
+    }
+
+    function test_SetOutboxRejectsEOA() public {
+        // An EOA has no code; the try/catch around supportsInterface fails and
+        // _validateOutbox reverts with InvalidOutbox.
+        address eoa = address(0xBADC0DE);
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(BridgeBurner.InvalidOutbox.selector, eoa));
+        bridge.bridgeBurner.setOutbox(eoa);
+    }
+
+    function test_SetOutboxRejectsSilentOutbox() public {
+        // A contract that exposes sendMessage but doesn't advertise IOutbox via
+        // ERC-165 must be rejected — this is the failure mode the audit found
+        // (tokens burn without a verifiable bridge message).
+        SilentOutbox silent = new SilentOutbox();
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(BridgeBurner.InvalidOutbox.selector, address(silent)));
+        bridge.bridgeBurner.setOutbox(address(silent));
+    }
+
+    function test_SetOutboxRejectsContractReturningFalse() public {
+        // A contract that implements supportsInterface but returns false for
+        // IOutbox is rejected by the require inside _validateOutbox.
+        LyingOutbox lying = new LyingOutbox();
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(BridgeBurner.InvalidOutbox.selector, address(lying)));
+        bridge.bridgeBurner.setOutbox(address(lying));
+    }
+
+    function test_SetOutboxAcceptsCanonicalOutbox() public {
+        // The canonical Outbox deployed in setUp advertises IOutbox via ERC-165,
+        // so swapping to a freshly-deployed canonical Outbox succeeds.
+        address newOutbox = address(bridge.outbox);
+        vm.prank(ADMIN);
+        bridge.bridgeBurner.setOutbox(newOutbox);
+        assertEq(address(bridge.bridgeBurner.outbox()), newOutbox);
+    }
+}
+
+/// @dev Exposes `sendMessage` matching the IOutbox signature but does NOT emit
+/// `MessageSent` and does NOT advertise IOutbox via ERC-165. Models the audit's
+/// "silent Outbox" attack — `BridgeBurner.setOutbox` must reject this.
+contract SilentOutbox {
+    function sendMessage(uint256, address, bytes calldata) external pure {
+        // no-op: deliberately does not emit MessageSent
+    }
+}
+
+/// @dev Implements supportsInterface but returns false for every interface ID,
+/// including IOutbox. `BridgeBurner.setOutbox` must reject this.
+contract LyingOutbox {
+    function sendMessage(uint256, address, bytes calldata) external pure {}
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return false;
+    }
 }


### PR DESCRIPTION
Validates the configured Outbox via ERC-165 (supportsInterface(IOutbox)) in both initialize and setOutbox. Rejects zero address, EOAs, and any contract that doesn't implement IOutbox.