### PR TITLE
Fix inbox threshold attestor invariant

### DIFF
--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -50,6 +50,7 @@ contract Inbox is
     error ZeroAddress();
     error AlreadyAttestor(address attestor);
     error NotAttestor(address attestor);
+    error InvalidThreshold(uint256 threshold, uint256 attestorCount);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -94,20 +95,24 @@ contract Inbox is
     }
 
     /// @notice Remove an address from the attestor set.
-    /// @dev WARNING: if removing this attestor leaves fewer active attestors than the current
-    /// threshold, all message delivery will be blocked until the threshold is lowered or new
-    /// attestors are added.
+    /// @dev Rejects the removal if it would leave fewer active attestors than the current
+    /// threshold. The owner must lower `threshold` first (via setThreshold) before pruning
+    /// the set below it.
     /// @param attestor Address to remove. Must be a current attestor.
     function removeAttestor(address attestor) external onlyOwner {
         require(_attestors.remove(attestor), NotAttestor(attestor));
+        uint256 newCount = _attestors.length();
+        require(newCount >= threshold, InvalidThreshold(threshold, newCount));
         emit AttestorRemoved(attestor);
     }
 
     /// @notice Update the minimum number of attestor signatures required to deliver a message.
-    /// @dev WARNING: a threshold of 0 or higher than the number of active attestors will cause
-    /// all message delivery to be rejected until the threshold is updated.
+    /// @dev Enforces `0 < threshold_ <= attestorCount` so the new threshold is always
+    /// satisfiable by the current attestor set.
     /// @param threshold_ New threshold value.
     function setThreshold(uint256 threshold_) external onlyOwner {
+        uint256 attestorCount = _attestors.length();
+        require(threshold_ > 0 && threshold_ <= attestorCount, InvalidThreshold(threshold_, attestorCount));
         threshold = threshold_;
         emit ThresholdSet(threshold_);
     }

--- a/test/bridge/Inbox.t.sol
+++ b/test/bridge/Inbox.t.sol
@@ -223,6 +223,54 @@ contract InboxTest is BridgeTestBase {
         }
     }
 
+    // ─── Threshold / attestor-count invariant (S-4 / #24) ───────────
+
+    function test_SetThresholdRejectsZero() public {
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Inbox.InvalidThreshold.selector, 0, 3));
+        bridge.inbox.setThreshold(0);
+    }
+
+    function test_SetThresholdRejectsValueAboveAttestorCount() public {
+        // 3 attestors are configured in setUp; threshold 4 is unsatisfiable.
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Inbox.InvalidThreshold.selector, 4, 3));
+        bridge.inbox.setThreshold(4);
+    }
+
+    function test_SetThresholdAcceptsExactlyAttestorCount() public {
+        // Boundary: threshold == attestorCount must succeed.
+        vm.prank(ADMIN);
+        bridge.inbox.setThreshold(3);
+        assertEq(bridge.inbox.threshold(), 3);
+    }
+
+    function test_RemoveAttestorRejectedIfDropsBelowThreshold() public {
+        // Raise threshold to the attestor count so any removal violates the invariant.
+        vm.prank(ADMIN);
+        bridge.inbox.setThreshold(3);
+
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Inbox.InvalidThreshold.selector, 3, 2));
+        bridge.inbox.removeAttestor(attestor2);
+
+        // Set is unchanged.
+        assertEq(bridge.inbox.getAttestorCount(), 3);
+        assertTrue(bridge.inbox.isAttestor(attestor2));
+    }
+
+    function test_RemoveAttestorAcceptedAtThresholdBoundary() public {
+        // Start: 3 attestors, threshold 2. Remove one: 2 attestors, still >= threshold.
+        vm.prank(ADMIN);
+        bridge.inbox.removeAttestor(attestor3);
+        assertEq(bridge.inbox.getAttestorCount(), 2);
+
+        // Removing another would drop below threshold and must revert.
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Inbox.InvalidThreshold.selector, 2, 1));
+        bridge.inbox.removeAttestor(attestor2);
+    }
+
     // ─── Invalid signature length ────────────────────────────────────
 
     function test_InvalidSignatureLengthReverts() public {


### PR DESCRIPTION
Enforces `0 < threshold ≤ attestorCount` in `setThreshold` and `removeAttestor`, so the owner cannot leave the inbox in a state where recvMessage is unsatisfiable.