### PR TITLE
allow minter revocation while paused

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -151,7 +151,11 @@ contract Stablecoin is
     }
 
     /// @dev Revokes MINTER_ROLE and clears the minting allowance atomically.
-    function removeMinter(address minter) public onlyRole(ADMIN_ROLE) whenNotPaused {
+    ///
+    /// Available while paused so an emergency response (pause) does not block emergency
+    /// revocation of a suspected-compromised minter. Token movements are still blocked
+    /// by `_update`'s pause check, so this does not open a new token-flow path.
+    function removeMinter(address minter) public onlyRole(ADMIN_ROLE) {
         require(hasRole(MINTER_ROLE, minter), "Minter does not exist");
         delete _minterAllowances[minter];
         _revokeRole(MINTER_ROLE, minter);
@@ -159,9 +163,14 @@ contract Stablecoin is
     }
 
     /// @dev Updates the minting allowance for an existing minter without changing their role.
-    function modifyMinterAllowance(address minter, uint256 allowance) public onlyRole(ADMIN_ROLE) whenNotPaused {
+    ///
+    /// While paused, only reductions (new <= current) are accepted, so the admin can de-risk
+    /// a compromised minter without an unpause-window race, but cannot raise allowances until
+    /// the contract is unpaused.
+    function modifyMinterAllowance(address minter, uint256 allowance) public onlyRole(ADMIN_ROLE) {
         require(hasRole(MINTER_ROLE, minter), "Minter does not exist");
         uint256 oldAllowance = _minterAllowances[minter];
+        require(!paused() || allowance <= oldAllowance, "Cannot increase allowance while paused");
         _minterAllowances[minter] = allowance;
         emit MinterAllowanceChanged(minter, oldAllowance, allowance);
     }

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -746,22 +746,37 @@ contract StablecoinTest is Test {
         stablecoin.burnFrom(account, amount);
     }
 
-    function test_CannotRemoveMinterWhenPaused() public {
+    function test_RemoveMinterSucceedsWhenPaused() public {
         vm.prank(PAUSER);
         stablecoin.pause();
 
         vm.prank(ADMIN);
-        vm.expectRevert(ENFORCED_PAUSE_ERROR);
         stablecoin.removeMinter(MINTER);
+
+        assertFalse(stablecoin.hasRole(stablecoin.MINTER_ROLE(), MINTER));
+        assertEq(stablecoin.minterAllowance(MINTER), 0);
     }
 
-    function test_CannotModifyMinterAllowanceWhenPaused() public {
+    function test_CannotIncreaseMinterAllowanceWhenPaused() public {
         vm.prank(PAUSER);
         stablecoin.pause();
 
         vm.prank(ADMIN);
-        vm.expectRevert(ENFORCED_PAUSE_ERROR);
+        vm.expectRevert("Cannot increase allowance while paused");
         stablecoin.modifyMinterAllowance(MINTER, 5000);
+    }
+
+    function test_CanDecreaseMinterAllowanceWhenPaused() public {
+        uint256 oldAllowance = stablecoin.minterAllowance(MINTER);
+        uint256 newAllowance = oldAllowance / 2;
+
+        vm.prank(PAUSER);
+        stablecoin.pause();
+
+        vm.prank(ADMIN);
+        stablecoin.modifyMinterAllowance(MINTER, newAllowance);
+
+        assertEq(stablecoin.minterAllowance(MINTER), newAllowance);
     }
 
     // ============ Role Permission Tests ============


### PR DESCRIPTION
removeMinter previously required the contract to be unpaused, so an emergency response (pause) blocked the very revocation the response was intended to enable. Compromised minters could front-run revocation on unpause.

removeMinter is now available while paused. modifyMinterAllowance remains available while paused only for reductions (new <= current), so admins can de-risk a minter mid-pause but cannot raise allowances. Token movements remain blocked by _update's pause check.
