### PR TITLE
accept signed delta in modifyMinterAllowance

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -14,6 +14,7 @@ import {
 } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 
 /**
  * @title Stablecoin
@@ -158,12 +159,28 @@ contract Stablecoin is
         emit MinterRemoved(minter);
     }
 
-    /// @dev Updates the minting allowance for an existing minter without changing their role.
-    function modifyMinterAllowance(address minter, uint256 allowance) public onlyRole(ADMIN_ROLE) whenNotPaused {
+    /// @dev Applies a signed `delta` to the minter's allowance, relative to its current value.
+    ///
+    /// Using a delta (rather than an absolute replacement) closes a front-running window:
+    /// with an absolute API, a planned change from A to B could be raced by a `mint(_, A)`
+    /// that consumes the OLD allowance just before B is written — effectively spending
+    /// both A and B. With a delta, the change is always relative to whatever the current
+    /// allowance is at the moment the change lands, so a front-running mint can only ever
+    /// shrink the post-state, never re-grant the consumed amount.
+    ///
+    /// Negative deltas saturate at zero (no underflow revert).
+    function modifyMinterAllowance(address minter, int256 delta) public onlyRole(ADMIN_ROLE) whenNotPaused {
         require(hasRole(MINTER_ROLE, minter), "Minter does not exist");
         uint256 oldAllowance = _minterAllowances[minter];
-        _minterAllowances[minter] = allowance;
-        emit MinterAllowanceChanged(minter, oldAllowance, allowance);
+        uint256 newAllowance;
+        if (delta >= 0) {
+            newAllowance = oldAllowance + uint256(delta);
+        } else {
+            uint256 magnitude = SignedMath.abs(delta);
+            newAllowance = magnitude >= oldAllowance ? 0 : oldAllowance - magnitude;
+        }
+        _minterAllowances[minter] = newAllowance;
+        emit MinterAllowanceChanged(minter, oldAllowance, newAllowance);
     }
 
     /**

--- a/test/Stablecoin.invariant.t.sol
+++ b/test/Stablecoin.invariant.t.sol
@@ -112,11 +112,13 @@ contract StablecoinHandler is Test {
         stablecoin.unfreeze(target);
     }
 
-    function modifyMinterAllowance(uint256 newAllowance) external {
-        newAllowance = bound(newAllowance, 0, type(uint128).max);
+    function modifyMinterAllowance(int256 delta) external {
+        int256 limit = int256(uint256(type(uint128).max));
+        delta = bound(delta, -limit, limit);
         vm.prank(admin);
-        stablecoin.modifyMinterAllowance(minter, newAllowance);
-        // Track the maximum allowance ever granted by admin
+        stablecoin.modifyMinterAllowance(minter, delta);
+        // Track the maximum allowance ever granted by admin (post-state after delta).
+        uint256 newAllowance = stablecoin.minterAllowance(minter);
         if (newAllowance > ghostMaxAllowanceGranted) {
             ghostMaxAllowanceGranted = newAllowance;
         }

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -89,33 +89,42 @@ contract StablecoinTest is Test {
         assertEq(stablecoin.minterAllowance(newMinter), 0);
     }
 
-    function test_ModifyMinterAllowance() public {
+    function test_ModifyMinterAllowanceIncreasesByDelta() public {
         uint256 oldAllowance = stablecoin.minterAllowance(MINTER);
-        uint256 newAllowance = 5000;
+        int256 delta = 4000;
+        uint256 newAllowance = oldAllowance + uint256(delta);
 
         vm.startPrank(ADMIN);
         vm.expectEmit();
         emit Stablecoin.MinterAllowanceChanged(MINTER, oldAllowance, newAllowance);
-        stablecoin.modifyMinterAllowance(MINTER, newAllowance);
+        stablecoin.modifyMinterAllowance(MINTER, delta);
         vm.stopPrank();
 
         assertEq(stablecoin.minterAllowance(MINTER), newAllowance);
     }
 
-    function test_ModifyMinterAllowanceCanDecrease() public {
+    function test_ModifyMinterAllowanceDecreasesByDelta() public {
         uint256 initialAllowance = stablecoin.minterAllowance(MINTER);
-        uint256 newAllowance = initialAllowance / 2;
+        int256 delta = -int256(initialAllowance / 2);
 
         vm.startPrank(ADMIN);
-        stablecoin.modifyMinterAllowance(MINTER, newAllowance);
+        stablecoin.modifyMinterAllowance(MINTER, delta);
         vm.stopPrank();
 
-        assertEq(stablecoin.minterAllowance(MINTER), newAllowance);
+        assertEq(stablecoin.minterAllowance(MINTER), initialAllowance - uint256(-delta));
+    }
+
+    function test_ModifyMinterAllowanceNegativeDeltaSaturatesAtZero() public {
+        uint256 initialAllowance = stablecoin.minterAllowance(MINTER);
+
+        vm.prank(ADMIN);
+        stablecoin.modifyMinterAllowance(MINTER, -int256(initialAllowance) - 1);
+
+        assertEq(stablecoin.minterAllowance(MINTER), 0);
     }
 
     function test_OnlyAdminCanModifyMinterAllowance() public {
         address nonAdmin = address(2);
-        uint256 amount = 1000;
 
         bytes memory expectedError = abi.encodeWithSignature(
             "AccessControlUnauthorizedAccount(address,bytes32)", nonAdmin, stablecoin.ADMIN_ROLE()
@@ -123,7 +132,7 @@ contract StablecoinTest is Test {
 
         vm.prank(nonAdmin);
         vm.expectRevert(expectedError);
-        stablecoin.modifyMinterAllowance(MINTER, amount);
+        stablecoin.modifyMinterAllowance(MINTER, 1000);
     }
 
     function test_OnlyAdminCanRemoveMinter() public {
@@ -549,7 +558,7 @@ contract StablecoinTest is Test {
         address nonMinter = address(0x999);
         vm.prank(ADMIN);
         vm.expectRevert("Minter does not exist");
-        stablecoin.modifyMinterAllowance(nonMinter, 1000);
+        stablecoin.modifyMinterAllowance(nonMinter, int256(1000));
     }
 
     // ============ Burner Enumeration Tests ============

--- a/test/bridge/Inbox.t.sol
+++ b/test/bridge/Inbox.t.sol
@@ -282,7 +282,7 @@ contract InboxTest is BridgeTestBase {
         bytes4[6] memory stablecoin = [
             bytes4(keccak256("addMinter(address,uint256)")),
             bytes4(keccak256("removeMinter(address)")),
-            bytes4(keccak256("modifyMinterAllowance(address,uint256)")),
+            bytes4(keccak256("modifyMinterAllowance(address,int256)")),
             bytes4(keccak256("freeze(address)")),
             bytes4(keccak256("unfreeze(address)")),
             bytes4(keccak256("pause()"))


### PR DESCRIPTION
Replacing the absolute-allowance API with a signed delta closes a front-running window: with an absolute call (A -> B), a minter could race a planned change by minting against the old allowance A just before B was written, effectively spending both. With a delta, the change is always applied relative to whatever the current allowance is at the moment the change lands, so a front-running mint can only shrink the post-state.

Negative deltas saturate at zero (no underflow revert), matching the spec's "shrink to zero, do not revert" semantics.

Tests, the invariant handler, and the Inbox selector-collision check are updated to the new signature `modifyMinterAllowance(address,int256)`.