### PR TITLE
block approvals while paused

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -239,6 +239,18 @@ contract Stablecoin is
         super._update(from, to, value);
     }
 
+    /// @dev Block allowance grants while paused. `_update` already blocks token movement,
+    /// but `approve` and `_spendAllowance` do not route through `_update`, so without
+    /// this override `approve()` (and the allowance bookkeeping inside `transferFrom` /
+    /// `burnFrom`) could still mutate state during a pause.
+    function _approve(address owner, address spender, uint256 value, bool emitEvent)
+        internal
+        override
+        whenNotPaused
+    {
+        super._approve(owner, spender, value, emitEvent);
+    }
+
     /// @dev UUPS upgrade authorization — only ADMIN_ROLE can upgrade the implementation.
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(ADMIN_ROLE) {}
 

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -337,6 +337,15 @@ contract StablecoinTest is Test {
         stablecoin.unfreeze(account);
     }
 
+    function test_CannotApproveWhenPaused() public {
+        vm.prank(PAUSER);
+        stablecoin.pause();
+
+        vm.prank(address(1));
+        vm.expectRevert(ENFORCED_PAUSE_ERROR);
+        stablecoin.approve(address(2), 100);
+    }
+
     function test_CannotAddMinterWhenPaused() public {
         address account = address(1);
         vm.prank(PAUSER);


### PR DESCRIPTION
_update enforces the pause for token movement (transfer, mint, burn), but approve and _spendAllowance do not route through _update. As a result, allowances could still be granted (or reduced) while paused.

Override the four-argument _approve hook with whenNotPaused so all allowance state changes — direct approve calls AND the internal allowance bookkeeping inside transferFrom / burnFrom — go through the pause check.