### PR TITLE
reject freeze(address(0))

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -200,7 +200,10 @@ contract Stablecoin is
     }
 
     /// @dev Freezes `account`, blocking all transfers to, from, and on behalf of it.
+    /// Reverts on `address(0)` because the zero address is used as `from` for mint and
+    /// `to` for burn; freezing it would break both flows.
     function freeze(address account) public onlyRole(FREEZER_ROLE) whenNotPaused {
+        require(account != address(0), "Cannot freeze zero address");
         frozen[account] = true;
         emit AccountFrozen(account);
     }

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -464,6 +464,12 @@ contract StablecoinTest is Test {
         success; // Silence unused variable warning (call reverts before this)
     }
 
+    function test_CannotFreezeZeroAddress() public {
+        vm.prank(FREEZER);
+        vm.expectRevert("Cannot freeze zero address");
+        stablecoin.freeze(address(0));
+    }
+
     function test_UnfreezeAccount() public {
         address account = address(1);
 


### PR DESCRIPTION
_update checks both `from` and `to` for frozen status. The zero address is used as `from` for mint and `to` for burn, so freezing it would silently break minting and burning until someone called unfreeze(0).

This PR rejects freeze(0) explicitly so this misconfiguration is impossible.
