### PR TITLE
remove redundant guards

### DIFF
--- a/script/DeployNewImplementation.s.sol
+++ b/script/DeployNewImplementation.s.sol
@@ -17,12 +17,10 @@ contract DeployNewImplementation is Script {
         Options memory opts;
         opts.referenceContract = referenceContract;
 
-        // 1. Validate storage layout (reverts on incompatibility)
-        console.log("Validating storage layout for", contractName);
-        Upgrades.validateUpgrade(contractName, opts);
-        console.log("Storage layout validation passed");
-
-        // 2. Deploy new implementation
+        // Deploy new implementation. prepareUpgrade runs validateUpgrade internally and
+        // reverts on storage-layout incompatibility, so an explicit prior call would be
+        // redundant.
+        console.log("Validating storage layout and deploying new implementation for", contractName);
         vm.startBroadcast();
         address newImpl = Upgrades.prepareUpgrade(contractName, opts);
         vm.stopBroadcast();

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -116,7 +116,9 @@ contract Stablecoin is
     }
 
     /// @dev Mints `value` tokens to `to`, deducting from the caller's minter allowance.
-    function mint(address to, uint256 value) public onlyRole(MINTER_ROLE) whenNotPaused {
+    /// The pause check lives in `_update` (invoked by `_mint`); the public function does
+    /// not need its own `whenNotPaused` modifier.
+    function mint(address to, uint256 value) public onlyRole(MINTER_ROLE) {
         uint256 allowance = _minterAllowances[msg.sender];
         require(allowance >= value, "Value exceeds allowance");
         _minterAllowances[msg.sender] = allowance - value;
@@ -131,30 +133,34 @@ contract Stablecoin is
     }
 
     /// @dev Burns `value` tokens from the caller's balance. Restricted to BURNER_ROLE.
-    function burn(uint256 value) public override onlyRole(BURNER_ROLE) whenNotPaused {
+    /// Pause is enforced inside `_update` (invoked by `_burn`).
+    function burn(uint256 value) public override onlyRole(BURNER_ROLE) {
         _burn(_msgSender(), value);
     }
 
     /// @dev Burns `value` tokens from `account` using the caller's ERC20 allowance. Restricted to BURNER_ROLE.
-    function burnFrom(address account, uint256 value) public override onlyRole(BURNER_ROLE) whenNotPaused {
+    /// Pause is enforced inside `_update` (invoked by `_burn`).
+    function burnFrom(address account, uint256 value) public override onlyRole(BURNER_ROLE) {
         _spendAllowance(account, _msgSender(), value);
         _burn(account, value);
     }
 
     /// @dev Grants MINTER_ROLE and sets the minting allowance atomically.
     /// Uses _grantRole to bypass the external grantRole admin check (see initialize @dev note).
+    /// _grantRole returns false when the role was already held, so the pre-check via
+    /// hasRole is redundant.
     function addMinter(address newMinter, uint256 allowance) public onlyRole(ADMIN_ROLE) whenNotPaused {
-        require(!hasRole(MINTER_ROLE, newMinter), "Minter already exists");
+        require(_grantRole(MINTER_ROLE, newMinter), "Minter already exists");
         _minterAllowances[newMinter] = allowance;
-        _grantRole(MINTER_ROLE, newMinter);
         emit MinterAdded(newMinter, allowance);
     }
 
     /// @dev Revokes MINTER_ROLE and clears the minting allowance atomically.
+    /// _revokeRole returns false when the role was not held, so the pre-check via
+    /// hasRole is redundant.
     function removeMinter(address minter) public onlyRole(ADMIN_ROLE) whenNotPaused {
-        require(hasRole(MINTER_ROLE, minter), "Minter does not exist");
+        require(_revokeRole(MINTER_ROLE, minter), "Minter does not exist");
         delete _minterAllowances[minter];
-        _revokeRole(MINTER_ROLE, minter);
         emit MinterRemoved(minter);
     }
 

--- a/src/bridge/deploy/BridgeConfig.sol
+++ b/src/bridge/deploy/BridgeConfig.sol
@@ -30,7 +30,6 @@ library BridgeConfig {
     error ThresholdZero();
     error ThresholdTooHigh(uint256 threshold, uint256 attestorCount);
     error MinterAllowanceZero();
-    error ZeroAttestor(uint256 index);
     error ZeroAllowedSender(uint256 index);
     error ZeroDstMinter(uint256 index);
 
@@ -76,10 +75,8 @@ library BridgeConfig {
         // Minter allowance
         require(config.minterAllowance > 0, MinterAllowanceZero());
 
-        // Zero-address checks on array entries
-        for (uint256 i = 0; i < config.attestors.length; i++) {
-            require(config.attestors[i] != address(0), ZeroAttestor(i));
-        }
+        // Zero-address checks on array entries. Attestors are checked by Inbox.addAttestor
+        // at configure-time, so they're not re-validated here.
         for (uint256 i = 0; i < config.allowedSenders.length; i++) {
             require(config.allowedSenders[i].sender != address(0), ZeroAllowedSender(i));
         }


### PR DESCRIPTION
Four duplicate checks that don't change behavior:

- Stablecoin.addMinter/removeMinter: drop the hasRole pre-check. The underlying _grantRole/_revokeRole returns false when the role state doesn't change, so the require can read that return directly.
- Stablecoin.mint/burn/burnFrom: drop whenNotPaused on the public functions but _update already enforces the pause on every token movement.
- BridgeConfig._validateConfig: drop the zero-address loop on attestors. Inbox.addAttestor (called inside configure) reverts on zero. Zero checks on allowedSenders and dstMinters stay because the underlying setters don't validate.
- DeployNewImplementation: drop the explicit Upgrades.validateUpgrade call but Upgrades.prepareUpgrade re-runs it.
