### PR TITLE
use pre-increment in for-loops

### DIFF
--- a/script/DeployBridge.s.sol
+++ b/script/DeployBridge.s.sol
@@ -45,7 +45,7 @@ contract DeployBridge is Script {
         require(srcChains.length == srcSenders.length, "allowed_senders length mismatch");
 
         config.allowedSenders = new BridgeConfig.AllowedSender[](srcChains.length);
-        for (uint256 i = 0; i < srcChains.length; i++) {
+        for (uint256 i = 0; i < srcChains.length; ++i) {
             config.allowedSenders[i] = BridgeConfig.AllowedSender(srcChains[i], srcSenders[i]);
         }
 
@@ -55,7 +55,7 @@ contract DeployBridge is Script {
         require(dstChains.length == dstMinters.length, "dst_minters length mismatch");
 
         config.dstMinters = new BridgeConfig.DstMinter[](dstChains.length);
-        for (uint256 i = 0; i < dstChains.length; i++) {
+        for (uint256 i = 0; i < dstChains.length; ++i) {
             config.dstMinters[i] = BridgeConfig.DstMinter(dstChains[i], dstMinters[i]);
         }
     }

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -172,7 +172,7 @@ contract Stablecoin is
     function getAllMinters() public view returns (MinterInfo[] memory) {
         address[] memory members = getRoleMembers(MINTER_ROLE);
         MinterInfo[] memory result = new MinterInfo[](members.length);
-        for (uint256 i = 0; i < members.length; i++) {
+        for (uint256 i = 0; i < members.length; ++i) {
             result[i] = MinterInfo({minter: members[i], allowance: _minterAllowances[members[i]]});
         }
         return result;

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -168,7 +168,7 @@ contract Inbox is
         bytes32 digest = _hashMessage(message);
 
         address prevSigner = address(0);
-        for (uint256 i = 0; i < sigCount; i++) {
+        for (uint256 i = 0; i < sigCount; ++i) {
             uint256 offset = i * 65;
             address signer = ECDSA.recoverCalldata(digest, signatures[offset:offset + 65]);
 

--- a/src/bridge/deploy/BridgeConfig.sol
+++ b/src/bridge/deploy/BridgeConfig.sol
@@ -47,18 +47,18 @@ library BridgeConfig {
         stablecoin.addMinter(address(c.bridgeMinter), config.minterAllowance);
 
         // 3. Set up Inbox attestors and threshold
-        for (uint256 i = 0; i < config.attestors.length; i++) {
+        for (uint256 i = 0; i < config.attestors.length; ++i) {
             c.inbox.addAttestor(config.attestors[i]);
         }
         c.inbox.setThreshold(config.threshold);
 
         // 4. Set BridgeMinter allowed senders (srcChain => expected BridgeBurner address)
-        for (uint256 i = 0; i < config.allowedSenders.length; i++) {
+        for (uint256 i = 0; i < config.allowedSenders.length; ++i) {
             c.bridgeMinter.setAllowedSender(config.allowedSenders[i].srcChain, config.allowedSenders[i].sender);
         }
 
         // 5. Set BridgeBurner destination minters (dstChain => BridgeMinter address on that chain)
-        for (uint256 i = 0; i < config.dstMinters.length; i++) {
+        for (uint256 i = 0; i < config.dstMinters.length; ++i) {
             c.bridgeBurner.setDstMinter(config.dstMinters[i].dstChain, config.dstMinters[i].minter);
         }
     }
@@ -77,13 +77,13 @@ library BridgeConfig {
         require(config.minterAllowance > 0, MinterAllowanceZero());
 
         // Zero-address checks on array entries
-        for (uint256 i = 0; i < config.attestors.length; i++) {
+        for (uint256 i = 0; i < config.attestors.length; ++i) {
             require(config.attestors[i] != address(0), ZeroAttestor(i));
         }
-        for (uint256 i = 0; i < config.allowedSenders.length; i++) {
+        for (uint256 i = 0; i < config.allowedSenders.length; ++i) {
             require(config.allowedSenders[i].sender != address(0), ZeroAllowedSender(i));
         }
-        for (uint256 i = 0; i < config.dstMinters.length; i++) {
+        for (uint256 i = 0; i < config.dstMinters.length; ++i) {
             require(config.dstMinters[i].minter != address(0), ZeroDstMinter(i));
         }
     }


### PR DESCRIPTION
Replace `i++` with `++i` in for-loop increments. The discarded post-increment temporary is what costs gas; pre-increment avoids it. 


