### PR TITLE
Add named parameters to mapping declarations

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -43,7 +43,7 @@ contract Stablecoin is
 
     mapping(address minter => uint256 allowance) private _minterAllowances;
     // Frozen accounts
-    mapping(address => bool) public frozen;
+    mapping(address account => bool isFrozen) public frozen;
     // Token decimals
     uint8 private _decimals;
 

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -41,7 +41,7 @@ contract Stablecoin is
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    mapping(address => uint256) private _minterAllowances;
+    mapping(address minter => uint256 allowance) private _minterAllowances;
     // Frozen accounts
     mapping(address => bool) public frozen;
     // Token decimals

--- a/src/bridge/BridgeBurner.sol
+++ b/src/bridge/BridgeBurner.sol
@@ -17,7 +17,7 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     IOutbox public outbox;
 
     /// @notice Per-destination-chain minter address (the BridgeMinter on that chain).
-    mapping(uint256 => address) public dstMinters;
+    mapping(uint256 dstChain => address minter) public dstMinters;
 
     event DstMinterSet(uint256 indexed dstChain, address minter);
     event OutboxSet(address outbox);

--- a/src/bridge/BridgeMinter.sol
+++ b/src/bridge/BridgeMinter.sol
@@ -17,7 +17,7 @@ contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
 
     /// @notice Mapping from source chain ID to the expected sender address (BridgeBurner on that chain).
     /// A source chain is allowed if and only if the mapped address is non-zero.
-    mapping(uint256 => address) public allowedSenders;
+    mapping(uint256 srcChain => address sender) public allowedSenders;
 
     event AllowedSenderSet(uint256 indexed srcChain, address sender);
     event InboxSet(address inbox);

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -34,7 +34,7 @@ contract Inbox is
     /// @dev Uses uint256 instead of bool to skip the read-modify-write the
     /// compiler emits for sub-word types. See OZ ReentrancyGuard for rationale:
     /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fcbae5394ae8ad52d8e580a3477db99814b9d565/contracts/utils/ReentrancyGuard.sol#L39-L43
-    mapping(bytes32 => uint256) public usedNonces;
+    mapping(bytes32 nonce => uint256 used) public usedNonces;
 
     event MessageDelivered(bytes32 indexed nonce, address indexed dstRecipient);
     event AttestorAdded(address indexed attestor);


### PR DESCRIPTION
Use the Solidity >=0.8.18 named-mapping syntax.