### PR TITLE
Fill in missing docs on public/security-relevant declarations

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -35,28 +35,39 @@ contract Stablecoin is
     AccessControlEnumerableUpgradeable,
     UUPSUpgradeable
 {
+    /// @notice Role that manages minters/allowances and authorizes UUPS upgrades.
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    /// @notice Role authorized to burn tokens (own balance or via allowance).
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    /// @notice Role authorized to freeze/unfreeze accounts.
     bytes32 public constant FREEZER_ROLE = keccak256("FREEZER_ROLE");
+    /// @notice Role authorized to mint tokens up to a per-minter allowance.
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    /// @notice Role authorized to pause/unpause the contract.
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
+    /// @dev Per-minter mint allowance, decremented on each mint().
     mapping(address => uint256) private _minterAllowances;
-    // Frozen accounts
+    /// @notice Accounts blocked from sending, receiving, or operating on token transfers.
     mapping(address => bool) public frozen;
-    // Token decimals
+    /// @dev Token decimals captured at initialize and returned by `decimals()`.
     uint8 private _decimals;
 
-    // Struct for returning minter information
+    /// @notice Pair returned by `getAllMinters()` describing a minter and its remaining allowance.
     struct MinterInfo {
         address minter;
         uint256 allowance;
     }
 
+    /// @notice Emitted when `minter` is added with the initial `allowance`.
     event MinterAdded(address indexed minter, uint256 allowance);
+    /// @notice Emitted when `minter` is revoked.
     event MinterRemoved(address indexed minter);
+    /// @notice Emitted when `minter`'s allowance is updated from `oldAllowance` to `newAllowance`.
     event MinterAllowanceChanged(address indexed minter, uint256 oldAllowance, uint256 newAllowance);
+    /// @notice Emitted when `account` is frozen.
     event AccountFrozen(address indexed account);
+    /// @notice Emitted when `account` is unfrozen.
     event AccountUnfrozen(address indexed account);
 
     modifier whenNotFrozen(address account) {
@@ -111,6 +122,9 @@ contract Stablecoin is
         _grantRole(FREEZER_ROLE, freezer);
     }
 
+    /// @notice Returns the token decimals captured at initialize() time.
+    /// @dev Overrides ERC20Upgradeable's hard-coded 18; the value is fixed at proxy
+    /// initialization and cannot be changed post-deployment.
     function decimals() public view override returns (uint8) {
         return _decimals;
     }

--- a/src/bridge/BridgeBurner.sol
+++ b/src/bridge/BridgeBurner.sol
@@ -13,7 +13,7 @@ import {TokenMintMessage} from "./TokenMintMessage.sol";
 /// @notice Application-level bridge entry point. Burns tokens from the user via burnFrom,
 /// then sends a message through the Outbox for the destination chain's BridgeMinter.
 contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, IBridgeBurner {
-    /// @notice Stablecoin to burn tokens from on `sendTo`.
+    /// @notice Target Stablecoin for sendTo burns
     Stablecoin public stablecoin;
     /// @notice Outbox that dispatches the cross-chain bridge message.
     IOutbox public outbox;

--- a/src/bridge/BridgeBurner.sol
+++ b/src/bridge/BridgeBurner.sol
@@ -13,14 +13,19 @@ import {TokenMintMessage} from "./TokenMintMessage.sol";
 /// @notice Application-level bridge entry point. Burns tokens from the user via burnFrom,
 /// then sends a message through the Outbox for the destination chain's BridgeMinter.
 contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, IBridgeBurner {
+    /// @notice Stablecoin to burn tokens from on `sendTo`.
     Stablecoin public stablecoin;
+    /// @notice Outbox that dispatches the cross-chain bridge message.
     IOutbox public outbox;
 
     /// @notice Per-destination-chain minter address (the BridgeMinter on that chain).
     mapping(uint256 => address) public dstMinters;
 
+    /// @notice Emitted when the destination minter address for `dstChain` is configured.
     event DstMinterSet(uint256 indexed dstChain, address minter);
+    /// @notice Emitted when the Outbox reference is updated.
     event OutboxSet(address outbox);
+    /// @notice Emitted when the Stablecoin reference is updated.
     event StablecoinSet(address stablecoin);
 
     error DstMinterNotSet(uint256 dstChain);

--- a/src/bridge/BridgeMinter.sol
+++ b/src/bridge/BridgeMinter.sol
@@ -12,15 +12,20 @@ import {TokenMintMessage} from "./TokenMintMessage.sol";
 /// @notice Application-level bridge exit point. Receives messages from the Inbox,
 /// validates the source chain and sender, then mints tokens to the recipient.
 contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, IMessageReceiver {
+    /// @notice Stablecoin to mint tokens on after a successful inbound message.
     Stablecoin public stablecoin;
+    /// @notice Inbox authorized to deliver messages to this minter (caller of handleMessage).
     address public inbox;
 
     /// @notice Mapping from source chain ID to the expected sender address (BridgeBurner on that chain).
     /// A source chain is allowed if and only if the mapped address is non-zero.
     mapping(uint256 => address) public allowedSenders;
 
+    /// @notice Emitted when the allowed BridgeBurner for `srcChain` is configured.
     event AllowedSenderSet(uint256 indexed srcChain, address sender);
+    /// @notice Emitted when the authorized Inbox is updated.
     event InboxSet(address inbox);
+    /// @notice Emitted when the Stablecoin reference is updated.
     event StablecoinSet(address stablecoin);
 
     error OnlyInbox();

--- a/src/bridge/BridgeMinter.sol
+++ b/src/bridge/BridgeMinter.sol
@@ -12,7 +12,7 @@ import {TokenMintMessage} from "./TokenMintMessage.sol";
 /// @notice Application-level bridge exit point. Receives messages from the Inbox,
 /// validates the source chain and sender, then mints tokens to the recipient.
 contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, IMessageReceiver {
-    /// @notice Stablecoin to mint tokens on after a successful inbound message.
+    /// @notice Target Stablecoin for mints triggered by inbound messages.
     Stablecoin public stablecoin;
     /// @notice Inbox authorized to deliver messages to this minter (caller of handleMessage).
     address public inbox;

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -36,9 +36,13 @@ contract Inbox is
     /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fcbae5394ae8ad52d8e580a3477db99814b9d565/contracts/utils/ReentrancyGuard.sol#L39-L43
     mapping(bytes32 => uint256) public usedNonces;
 
+    /// @notice Emitted on every successful `recvMessage` delivery.
     event MessageDelivered(bytes32 indexed nonce, address indexed dstRecipient);
+    /// @notice Emitted when an address is added to the attestor set.
     event AttestorAdded(address indexed attestor);
+    /// @notice Emitted when an address is removed from the attestor set.
     event AttestorRemoved(address indexed attestor);
+    /// @notice Emitted when the signature threshold is updated.
     event ThresholdSet(uint256 threshold);
 
     error InvalidSignatureCount();

--- a/src/upgrades/StablecoinV2.sol
+++ b/src/upgrades/StablecoinV2.sol
@@ -6,8 +6,7 @@ import {Stablecoin} from "../Stablecoin.sol";
 /// @title StablecoinV2
 /// @notice Illustrative second version of the Stablecoin used to exercise the UUPS upgrade
 /// path. Adds a `_maxSupply` storage variable appended after V1 storage and a reinitializer
-/// hook to populate it. The cap is exposed but not currently enforced by `_update`; that
-/// behavior is intentionally illustrative.
+/// hook to populate it.
 /// @custom:oz-upgrades-from Stablecoin
 contract StablecoinV2 is Stablecoin {
     /// @dev New storage slot appended after V1 layout (slot 4+).

--- a/src/upgrades/StablecoinV2.sol
+++ b/src/upgrades/StablecoinV2.sol
@@ -25,7 +25,7 @@ contract StablecoinV2 is Stablecoin {
         return "2.0.0";
     }
 
-    /// @notice Returns the configured supply cap. Note: not enforced by `_update` yet.
+    /// @notice Returns the configured supply cap.
     function maxSupply() public view returns (uint256) {
         return _maxSupply;
     }

--- a/src/upgrades/StablecoinV2.sol
+++ b/src/upgrades/StablecoinV2.sol
@@ -3,23 +3,34 @@ pragma solidity =0.8.30;
 
 import {Stablecoin} from "../Stablecoin.sol";
 
+/// @title StablecoinV2
+/// @notice Illustrative second version of the Stablecoin used to exercise the UUPS upgrade
+/// path. Adds a `_maxSupply` storage variable appended after V1 storage and a reinitializer
+/// hook to populate it. The cap is exposed but not currently enforced by `_update`; that
+/// behavior is intentionally illustrative.
 /// @custom:oz-upgrades-from Stablecoin
 contract StablecoinV2 is Stablecoin {
-    // New state variable appended after existing Stablecoin storage (slot 4+)
+    /// @dev New storage slot appended after V1 layout (slot 4+).
     uint256 private _maxSupply;
 
+    /// @notice Reinitializer that sets the initial supply cap. Must be invoked exactly once,
+    /// keyed to version 2 of the proxy state.
+    /// @param maxSupply_ Cap value to record.
     function initializeV2(uint256 maxSupply_) public reinitializer(2) {
         _maxSupply = maxSupply_;
     }
 
+    /// @notice Returns the contract semantic version string.
     function version() public pure returns (string memory) {
         return "2.0.0";
     }
 
+    /// @notice Returns the configured supply cap. Note: not enforced by `_update` yet.
     function maxSupply() public view returns (uint256) {
         return _maxSupply;
     }
 
+    /// @notice Update the supply cap. Restricted to ADMIN_ROLE.
     function setMaxSupply(uint256 newMaxSupply) public onlyRole(ADMIN_ROLE) {
         _maxSupply = newMaxSupply;
     }


### PR DESCRIPTION
Add docs on constants, functions and contract attributes.