### PR TITLE
migrate require strings to custom errors

### DIFF
--- a/script/DeployBridge.s.sol
+++ b/script/DeployBridge.s.sol
@@ -10,6 +10,9 @@ import {BridgeConfig} from "src/bridge/deploy/BridgeConfig.sol";
 /// @notice Deploys and configures all bridge contracts from a TOML configuration file.
 /// Usage: forge script script/DeployBridge.s.sol --sig "run(string)" <path-to-config.toml>
 contract DeployBridge is Script {
+    error AllowedSendersLengthMismatch(uint256 chainCount, uint256 senderCount);
+    error DstMintersLengthMismatch(uint256 chainCount, uint256 minterCount);
+
     function run(string memory configPath) public {
         string memory toml = vm.readFile(configPath);
 
@@ -42,7 +45,7 @@ contract DeployBridge is Script {
         // Parse allowed senders
         uint256[] memory srcChains = vm.parseTomlUintArray(toml, ".bridge.allowed_senders.src_chain");
         address[] memory srcSenders = vm.parseTomlAddressArray(toml, ".bridge.allowed_senders.sender");
-        require(srcChains.length == srcSenders.length, "allowed_senders length mismatch");
+        require(srcChains.length == srcSenders.length, AllowedSendersLengthMismatch(srcChains.length, srcSenders.length));
 
         config.allowedSenders = new BridgeConfig.AllowedSender[](srcChains.length);
         for (uint256 i = 0; i < srcChains.length; i++) {
@@ -52,7 +55,7 @@ contract DeployBridge is Script {
         // Parse destination minters
         uint256[] memory dstChains = vm.parseTomlUintArray(toml, ".bridge.dst_minters.dst_chain");
         address[] memory dstMinters = vm.parseTomlAddressArray(toml, ".bridge.dst_minters.minter");
-        require(dstChains.length == dstMinters.length, "dst_minters length mismatch");
+        require(dstChains.length == dstMinters.length, DstMintersLengthMismatch(dstChains.length, dstMinters.length));
 
         config.dstMinters = new BridgeConfig.DstMinter[](dstChains.length);
         for (uint256 i = 0; i < dstChains.length; i++) {

--- a/script/SimulateUpgrade.s.sol
+++ b/script/SimulateUpgrade.s.sol
@@ -17,6 +17,12 @@ import {Stablecoin} from "src/Stablecoin.sol";
 ///       --sig 'run(address,string,bytes,address,string)' \
 ///       $PROXY "StablecoinV2.sol" $REINIT_DATA $ADMIN "Stablecoin.sol"
 contract SimulateUpgrade is Script {
+    error ProxyHasNoCode(address proxy);
+    error AdminMissingRole(address admin);
+    error ImplementationUnchanged(address impl);
+    error ImplementationIsZero();
+    error StateChanged(string field);
+
     function run(
         address proxyAddress,
         string memory contractName,
@@ -24,7 +30,7 @@ contract SimulateUpgrade is Script {
         address admin,
         string memory referenceContract
     ) public {
-        require(proxyAddress.code.length > 0, "Proxy address has no code");
+        require(proxyAddress.code.length > 0, ProxyHasNoCode(proxyAddress));
 
         Stablecoin coin = Stablecoin(proxyAddress);
 
@@ -48,7 +54,7 @@ contract SimulateUpgrade is Script {
         console.log("Implementation:", preImpl);
 
         // ── 2. Verify admin has ADMIN_ROLE ──────────────────────
-        require(coin.hasRole(coin.ADMIN_ROLE(), admin), "Provided admin does not have ADMIN_ROLE");
+        require(coin.hasRole(coin.ADMIN_ROLE(), admin), AdminMissingRole(admin));
         console.log("");
         console.log("Admin verified:", admin);
 
@@ -74,16 +80,16 @@ contract SimulateUpgrade is Script {
         console.log("=== Post-upgrade verification ===");
 
         address postImpl = Upgrades.getImplementationAddress(proxyAddress);
-        require(postImpl != preImpl, "FAIL: Implementation address unchanged");
-        require(postImpl != address(0), "FAIL: Implementation is zero address");
+        require(postImpl != preImpl, ImplementationUnchanged(preImpl));
+        require(postImpl != address(0), ImplementationIsZero());
         console.log("New implementation:", postImpl);
 
-        require(keccak256(bytes(coin.name())) == keccak256(bytes(preName)), "FAIL: Name changed");
-        require(keccak256(bytes(coin.symbol())) == keccak256(bytes(preSymbol)), "FAIL: Symbol changed");
-        require(coin.decimals() == preDecimals, "FAIL: Decimals changed");
-        require(coin.totalSupply() == preTotalSupply, "FAIL: Total supply changed");
-        require(coin.paused() == prePaused, "FAIL: Paused state changed");
-        require(coin.getMinterCount() == preMinterCount, "FAIL: Minter count changed");
+        require(keccak256(bytes(coin.name())) == keccak256(bytes(preName)), StateChanged("name"));
+        require(keccak256(bytes(coin.symbol())) == keccak256(bytes(preSymbol)), StateChanged("symbol"));
+        require(coin.decimals() == preDecimals, StateChanged("decimals"));
+        require(coin.totalSupply() == preTotalSupply, StateChanged("totalSupply"));
+        require(coin.paused() == prePaused, StateChanged("paused"));
+        require(coin.getMinterCount() == preMinterCount, StateChanged("minterCount"));
 
         console.log("");
         console.log("=== SIMULATION PASSED ===");

--- a/script/SwitchImplementation.s.sol
+++ b/script/SwitchImplementation.s.sol
@@ -23,6 +23,11 @@ import {Stablecoin} from "src/Stablecoin.sol";
 ///       --sig 'run(address,address,bytes,string,string)' \
 ///       $PROXY $NEW_IMPL 0x "StablecoinV2.sol" "Stablecoin.sol"
 contract SwitchImplementation is Script {
+    error ProxyHasNoCode(address proxy);
+    error ImplementationHasNoCode(address impl);
+    error AlreadyAtImplementation(address impl);
+    error ImplementationNotUpdated(address expected, address actual);
+
     function run(
         address proxyAddress,
         address newImplementation,
@@ -31,11 +36,11 @@ contract SwitchImplementation is Script {
         string memory referenceContract
     ) public {
         // ── Pre-upgrade checks ──────────────────────────────────
-        require(proxyAddress.code.length > 0, "Proxy address has no code");
-        require(newImplementation.code.length > 0, "Implementation address has no code");
+        require(proxyAddress.code.length > 0, ProxyHasNoCode(proxyAddress));
+        require(newImplementation.code.length > 0, ImplementationHasNoCode(newImplementation));
 
         address implBefore = Upgrades.getImplementationAddress(proxyAddress);
-        require(newImplementation != implBefore, "Proxy already points to this implementation");
+        require(newImplementation != implBefore, AlreadyAtImplementation(newImplementation));
 
         Stablecoin coin = Stablecoin(proxyAddress);
         console.log("Proxy:", proxyAddress);
@@ -60,7 +65,7 @@ contract SwitchImplementation is Script {
 
         // ── Post-upgrade checks ─────────────────────────────────
         address implAfter = Upgrades.getImplementationAddress(proxyAddress);
-        require(implAfter == newImplementation, "Implementation not updated correctly");
+        require(implAfter == newImplementation, ImplementationNotUpdated(newImplementation, implAfter));
 
         console.log("");
         console.log("Upgrade complete!");

--- a/script/UpgradeStablecoin.s.sol
+++ b/script/UpgradeStablecoin.s.sol
@@ -16,6 +16,10 @@ import {Stablecoin} from "src/Stablecoin.sol";
 ///       --sig 'run(address,string,bytes,string)' \
 ///       $PROXY "StablecoinV2.sol" $REINIT_DATA "Stablecoin.sol"
 contract UpgradeStablecoin is Script {
+    error ProxyHasNoCode(address proxy);
+    error ImplementationUnchanged(address current);
+    error ImplementationIsZero();
+
     function run(
         address proxyAddress,
         string memory contractName,
@@ -23,7 +27,7 @@ contract UpgradeStablecoin is Script {
         string memory referenceContract
     ) public {
         // ── Pre-upgrade checks ──────────────────────────────────
-        require(proxyAddress.code.length > 0, "Proxy address has no code");
+        require(proxyAddress.code.length > 0, ProxyHasNoCode(proxyAddress));
 
         address implBefore = Upgrades.getImplementationAddress(proxyAddress);
         console.log("Proxy address:", proxyAddress);
@@ -49,8 +53,8 @@ contract UpgradeStablecoin is Script {
 
         // ── Post-upgrade checks ─────────────────────────────────
         address implAfter = Upgrades.getImplementationAddress(proxyAddress);
-        require(implAfter != implBefore, "Implementation address did not change");
-        require(implAfter != address(0), "Implementation address is zero");
+        require(implAfter != implBefore, ImplementationUnchanged(implBefore));
+        require(implAfter != address(0), ImplementationIsZero());
 
         console.log("");
         console.log("Upgrade complete!");

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -59,6 +59,11 @@ contract Stablecoin is
     event AccountFrozen(address indexed account);
     event AccountUnfrozen(address indexed account);
 
+    error ValueExceedsAllowance(uint256 requested, uint256 allowance);
+    error MinterAlreadyExists(address minter);
+    error MinterDoesNotExist(address minter);
+    error AccountIsFrozen(address account);
+
     modifier whenNotFrozen(address account) {
         _whenNotFrozen(account);
         _;
@@ -118,7 +123,7 @@ contract Stablecoin is
     /// @dev Mints `value` tokens to `to`, deducting from the caller's minter allowance.
     function mint(address to, uint256 value) public onlyRole(MINTER_ROLE) whenNotPaused {
         uint256 allowance = _minterAllowances[msg.sender];
-        require(allowance >= value, "Value exceeds allowance");
+        require(allowance >= value, ValueExceedsAllowance(value, allowance));
         _minterAllowances[msg.sender] = allowance - value;
         _mint(to, value);
     }
@@ -144,7 +149,7 @@ contract Stablecoin is
     /// @dev Grants MINTER_ROLE and sets the minting allowance atomically.
     /// Uses _grantRole to bypass the external grantRole admin check (see initialize @dev note).
     function addMinter(address newMinter, uint256 allowance) public onlyRole(ADMIN_ROLE) whenNotPaused {
-        require(!hasRole(MINTER_ROLE, newMinter), "Minter already exists");
+        require(!hasRole(MINTER_ROLE, newMinter), MinterAlreadyExists(newMinter));
         _minterAllowances[newMinter] = allowance;
         _grantRole(MINTER_ROLE, newMinter);
         emit MinterAdded(newMinter, allowance);
@@ -152,7 +157,7 @@ contract Stablecoin is
 
     /// @dev Revokes MINTER_ROLE and clears the minting allowance atomically.
     function removeMinter(address minter) public onlyRole(ADMIN_ROLE) whenNotPaused {
-        require(hasRole(MINTER_ROLE, minter), "Minter does not exist");
+        require(hasRole(MINTER_ROLE, minter), MinterDoesNotExist(minter));
         delete _minterAllowances[minter];
         _revokeRole(MINTER_ROLE, minter);
         emit MinterRemoved(minter);
@@ -160,7 +165,7 @@ contract Stablecoin is
 
     /// @dev Updates the minting allowance for an existing minter without changing their role.
     function modifyMinterAllowance(address minter, uint256 allowance) public onlyRole(ADMIN_ROLE) whenNotPaused {
-        require(hasRole(MINTER_ROLE, minter), "Minter does not exist");
+        require(hasRole(MINTER_ROLE, minter), MinterDoesNotExist(minter));
         uint256 oldAllowance = _minterAllowances[minter];
         _minterAllowances[minter] = allowance;
         emit MinterAllowanceChanged(minter, oldAllowance, allowance);
@@ -243,6 +248,6 @@ contract Stablecoin is
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(ADMIN_ROLE) {}
 
     function _whenNotFrozen(address account) internal view {
-        require(!frozen[account], "Frozen account");
+        require(!frozen[account], AccountIsFrozen(account));
     }
 }

--- a/src/bridge/deploy/BridgeDeploy.sol
+++ b/src/bridge/deploy/BridgeDeploy.sol
@@ -21,6 +21,9 @@ library BridgeDeploy {
         BridgeMinter bridgeMinter;
     }
 
+    error Create2DeployFailed(bytes32 salt);
+    error Create2DeploymentEmpty(bytes32 salt, address deployed);
+
     /// @notice Deploy all bridge contracts using deterministic CREATE2 addresses.
     /// @param baseSalt Base salt from which per-contract salts are derived.
     /// @param owner Owner of all bridge contracts (can upgrade and configure).
@@ -88,7 +91,7 @@ library BridgeDeploy {
     function _deploy(bytes32 salt, bytes memory bytecode) private returns (address deployed) {
         deployed = Create2.computeAddress(salt, keccak256(bytecode), ARACHNID);
         (bool success,) = ARACHNID.call(abi.encodePacked(salt, bytecode));
-        require(success, "BridgeDeploy: CREATE2 failed");
-        require(deployed.code.length > 0, "BridgeDeploy: deployment produced no code");
+        require(success, Create2DeployFailed(salt));
+        require(deployed.code.length > 0, Create2DeploymentEmpty(salt, deployed));
     }
 }

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -16,7 +16,6 @@ contract StablecoinTest is Test {
     address public constant FREEZER = 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65;
 
     bytes public constant ENFORCED_PAUSE_ERROR = abi.encodeWithSignature("EnforcedPause()");
-    bytes public constant FREEZED_ACCOUNT_ERROR = "Frozen account";
 
     function setUp() public {
         vm.startPrank(ADMIN);
@@ -69,7 +68,7 @@ contract StablecoinTest is Test {
         stablecoin.addMinter(newMinter, amount);
 
         // Try to add the same minter again - should revert
-        vm.expectRevert("Minter already exists");
+        vm.expectPartialRevert(Stablecoin.MinterAlreadyExists.selector);
         stablecoin.addMinter(newMinter, amount);
         vm.stopPrank();
     }
@@ -149,7 +148,7 @@ contract StablecoinTest is Test {
         stablecoin.addMinter(newMinter, amount);
 
         vm.prank(newMinter);
-        vm.expectRevert("Value exceeds allowance");
+        vm.expectPartialRevert(Stablecoin.ValueExceedsAllowance.selector);
         stablecoin.mint(newMinter, amount + 1);
     }
 
@@ -355,7 +354,7 @@ contract StablecoinTest is Test {
         stablecoin.freeze(frozenAccount);
 
         vm.prank(MINTER);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         stablecoin.mint(frozenAccount, amount);
     }
 
@@ -372,7 +371,7 @@ contract StablecoinTest is Test {
         stablecoin.freeze(frozenAccount);
 
         vm.prank(frozenAccount);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         bool success = stablecoin.transfer(otherAccount, amount);
         success; // Silence unused variable warning (call reverts before this)
     }
@@ -390,7 +389,7 @@ contract StablecoinTest is Test {
         stablecoin.freeze(frozenAccount);
 
         vm.prank(otherAccount);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         bool success = stablecoin.transfer(frozenAccount, amount);
         success; // Silence unused variable warning (call reverts before this)
     }
@@ -413,7 +412,7 @@ contract StablecoinTest is Test {
         stablecoin.freeze(spender);
 
         vm.prank(spender);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         bool success = stablecoin.transferFrom(owner, receiver, amount);
         success; // Silence unused variable warning (call reverts before this)
     }
@@ -436,7 +435,7 @@ contract StablecoinTest is Test {
         stablecoin.freeze(owner);
 
         vm.prank(spender);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         bool success = stablecoin.transferFrom(owner, receiver, amount);
         success; // Silence unused variable warning (call reverts before this)
     }
@@ -459,7 +458,7 @@ contract StablecoinTest is Test {
         stablecoin.freeze(receiver);
 
         vm.prank(spender);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         bool success = stablecoin.transferFrom(owner, receiver, amount);
         success; // Silence unused variable warning (call reverts before this)
     }
@@ -541,14 +540,14 @@ contract StablecoinTest is Test {
     function test_CannotRemoveNonExistentMinter() public {
         address nonMinter = address(0x999);
         vm.prank(ADMIN);
-        vm.expectRevert("Minter does not exist");
+        vm.expectPartialRevert(Stablecoin.MinterDoesNotExist.selector);
         stablecoin.removeMinter(nonMinter);
     }
 
     function test_CannotModifyNonExistentMinterAllowance() public {
         address nonMinter = address(0x999);
         vm.prank(ADMIN);
-        vm.expectRevert("Minter does not exist");
+        vm.expectPartialRevert(Stablecoin.MinterDoesNotExist.selector);
         stablecoin.modifyMinterAllowance(nonMinter, 1000);
     }
 
@@ -663,7 +662,7 @@ contract StablecoinTest is Test {
         stablecoin.addMinter(testMinter, allowance);
 
         vm.prank(testMinter);
-        vm.expectRevert("Value exceeds allowance");
+        vm.expectPartialRevert(Stablecoin.ValueExceedsAllowance.selector);
         stablecoin.mint(address(0x201), mintAmount);
     }
 
@@ -705,7 +704,7 @@ contract StablecoinTest is Test {
 
         // Frozen minter cannot mint (msg.sender is checked in _update)
         vm.prank(MINTER);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         stablecoin.mint(recipient, amount);
     }
 
@@ -722,7 +721,7 @@ contract StablecoinTest is Test {
 
         // Frozen burner cannot burn (msg.sender is checked in _update)
         vm.prank(BURNER);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         stablecoin.burn(amount);
     }
 
@@ -742,7 +741,7 @@ contract StablecoinTest is Test {
 
         // Frozen burner cannot burnFrom (msg.sender is checked in _update)
         vm.prank(BURNER);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         stablecoin.burnFrom(account, amount);
     }
 
@@ -889,7 +888,7 @@ contract StablecoinTest is Test {
 
         // Burner cannot burn from frozen account
         vm.prank(BURNER);
-        vm.expectRevert(FREEZED_ACCOUNT_ERROR);
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         stablecoin.burnFrom(account, amount);
     }
 

--- a/test/UpgradeStablecoin.t.sol
+++ b/test/UpgradeStablecoin.t.sol
@@ -201,13 +201,13 @@ contract UpgradeStablecoinTest is Test {
 
         // Transfer TO frozen account still reverts
         vm.prank(USER1);
-        vm.expectRevert("Frozen account");
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         bool success = stablecoin.transfer(USER2, 100e6);
         assertFalse(success);
 
         // Transfer FROM frozen account still reverts
         vm.prank(USER2);
-        vm.expectRevert("Frozen account");
+        vm.expectPartialRevert(Stablecoin.AccountIsFrozen.selector);
         success = stablecoin.transfer(USER1, 100e6);
         assertFalse(success);
     }


### PR DESCRIPTION
Standardizes on custom errors across production contracts and scripts, matching the style already used in Inbox/BridgeBurner/BridgeMinter. 
