### PR TITLE
reject zero-addresses

### DIFF
--- a/script/DeployStablecoin.s.sol
+++ b/script/DeployStablecoin.s.sol
@@ -6,10 +6,7 @@ import {Stablecoin} from "src/Stablecoin.sol";
 import {Upgrades} from "@openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract DeployStablecoin is Script {
-    error AdminIsZeroAddress();
-    error BurnerIsZeroAddress();
-    error PauserIsZeroAddress();
-    error FreezerIsZeroAddress();
+    error ZeroAddress(bytes32 field);
 
     function run(
         string memory name,
@@ -22,10 +19,10 @@ contract DeployStablecoin is Script {
     ) public {
         // Fail fast before encoding the initializer so a typo'd / missing env var
         // doesn't burn gas on a CREATE2 deploy that the contract would revert anyway.
-        require(admin != address(0), AdminIsZeroAddress());
-        require(burner != address(0), BurnerIsZeroAddress());
-        require(pauser != address(0), PauserIsZeroAddress());
-        require(freezer != address(0), FreezerIsZeroAddress());
+        require(admin != address(0), ZeroAddress("admin"));
+        require(burner != address(0), ZeroAddress("burner"));
+        require(pauser != address(0), ZeroAddress("pauser"));
+        require(freezer != address(0), ZeroAddress("freezer"));
 
         bytes memory initializerData =
             abi.encodeCall(Stablecoin.initialize, (name, symbol, decimals, admin, burner, pauser, freezer));

--- a/script/DeployStablecoin.s.sol
+++ b/script/DeployStablecoin.s.sol
@@ -6,6 +6,11 @@ import {Stablecoin} from "src/Stablecoin.sol";
 import {Upgrades} from "@openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract DeployStablecoin is Script {
+    error AdminIsZeroAddress();
+    error BurnerIsZeroAddress();
+    error PauserIsZeroAddress();
+    error FreezerIsZeroAddress();
+
     function run(
         string memory name,
         string memory symbol,
@@ -15,6 +20,13 @@ contract DeployStablecoin is Script {
         address pauser,
         address freezer
     ) public {
+        // Fail fast before encoding the initializer so a typo'd / missing env var
+        // doesn't burn gas on a CREATE2 deploy that the contract would revert anyway.
+        require(admin != address(0), AdminIsZeroAddress());
+        require(burner != address(0), BurnerIsZeroAddress());
+        require(pauser != address(0), PauserIsZeroAddress());
+        require(freezer != address(0), FreezerIsZeroAddress());
+
         bytes memory initializerData = abi.encodeCall(
             Stablecoin.initialize, (name, symbol, decimals, admin, burner, pauser, freezer)
         );

--- a/script/DeployStablecoin.s.sol
+++ b/script/DeployStablecoin.s.sol
@@ -27,9 +27,8 @@ contract DeployStablecoin is Script {
         require(pauser != address(0), PauserIsZeroAddress());
         require(freezer != address(0), FreezerIsZeroAddress());
 
-        bytes memory initializerData = abi.encodeCall(
-            Stablecoin.initialize, (name, symbol, decimals, admin, burner, pauser, freezer)
-        );
+        bytes memory initializerData =
+            abi.encodeCall(Stablecoin.initialize, (name, symbol, decimals, admin, burner, pauser, freezer));
 
         vm.startBroadcast();
         address stablecoin = Upgrades.deployUUPSProxy("Stablecoin.sol", initializerData);

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -59,6 +59,8 @@ contract Stablecoin is
     event AccountFrozen(address indexed account);
     event AccountUnfrozen(address indexed account);
 
+    error ZeroAddress(bytes32 role);
+
     modifier whenNotFrozen(address account) {
         _whenNotFrozen(account);
         _;
@@ -93,10 +95,10 @@ contract Stablecoin is
         address pauser,
         address freezer
     ) public initializer {
-        require(admin != address(0), "ADMIN_ROLE is zero address");
-        require(burner != address(0), "BURNER_ROLE is zero address");
-        require(pauser != address(0), "PAUSER_ROLE is zero address");
-        require(freezer != address(0), "FREEZER_ROLE is zero address");
+        if (admin == address(0)) revert ZeroAddress(ADMIN_ROLE);
+        if (burner == address(0)) revert ZeroAddress(BURNER_ROLE);
+        if (pauser == address(0)) revert ZeroAddress(PAUSER_ROLE);
+        if (freezer == address(0)) revert ZeroAddress(FREEZER_ROLE);
 
         __ERC20_init(name, symbol);
         __ERC20Burnable_init();

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -93,6 +93,11 @@ contract Stablecoin is
         address pauser,
         address freezer
     ) public initializer {
+        require(admin != address(0), "ADMIN_ROLE is zero address");
+        require(burner != address(0), "BURNER_ROLE is zero address");
+        require(pauser != address(0), "PAUSER_ROLE is zero address");
+        require(freezer != address(0), "FREEZER_ROLE is zero address");
+
         __ERC20_init(name, symbol);
         __ERC20Burnable_init();
         __ERC20Pausable_init();

--- a/src/bridge/BridgeBurner.sol
+++ b/src/bridge/BridgeBurner.sol
@@ -24,7 +24,7 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     event StablecoinSet(address stablecoin);
 
     error DstMinterNotSet(uint256 dstChain);
-    error ZeroAddress();
+    error ZeroAddress(bytes32 field);
     error ZeroRecipient();
     error ZeroAmount();
     error SameChain();
@@ -39,8 +39,8 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @param stablecoin_ Address of the stablecoin contract to burn tokens from.
     /// @param outbox_ Address of the Outbox contract used to send cross-chain messages.
     function initialize(address owner_, address stablecoin_, address outbox_) public initializer {
-        require(stablecoin_ != address(0), ZeroAddress());
-        require(outbox_ != address(0), ZeroAddress());
+        require(stablecoin_ != address(0), ZeroAddress("stablecoin"));
+        require(outbox_ != address(0), ZeroAddress("outbox"));
         __Ownable_init(owner_);
         stablecoin = Stablecoin(stablecoin_);
         outbox = IOutbox(outbox_);
@@ -55,7 +55,7 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @notice Update the Outbox contract reference.
     /// @param outbox_ Address of the new Outbox contract.
     function setOutbox(address outbox_) external onlyOwner {
-        require(outbox_ != address(0), ZeroAddress());
+        require(outbox_ != address(0), ZeroAddress("outbox"));
         outbox = IOutbox(outbox_);
         emit OutboxSet(outbox_);
     }
@@ -63,7 +63,7 @@ contract BridgeBurner is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @notice Update the stablecoin contract reference.
     /// @param stablecoin_ Address of the new stablecoin contract.
     function setStablecoin(address stablecoin_) external onlyOwner {
-        require(stablecoin_ != address(0), ZeroAddress());
+        require(stablecoin_ != address(0), ZeroAddress("stablecoin"));
         stablecoin = Stablecoin(stablecoin_);
         emit StablecoinSet(stablecoin_);
     }

--- a/src/bridge/BridgeMinter.sol
+++ b/src/bridge/BridgeMinter.sol
@@ -25,7 +25,7 @@ contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
 
     error OnlyInbox();
     error DisallowedSender(uint256 srcChain, address srcSender);
-    error ZeroAddress();
+    error ZeroAddress(bytes32 field);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -37,8 +37,8 @@ contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @param stablecoin_ Address of the stablecoin contract to mint tokens on.
     /// @param inbox_ Address of the Inbox contract authorized to deliver messages.
     function initialize(address owner_, address stablecoin_, address inbox_) public initializer {
-        require(stablecoin_ != address(0), ZeroAddress());
-        require(inbox_ != address(0), ZeroAddress());
+        require(stablecoin_ != address(0), ZeroAddress("stablecoin"));
+        require(inbox_ != address(0), ZeroAddress("inbox"));
         __Ownable_init(owner_);
         stablecoin = Stablecoin(stablecoin_);
         inbox = inbox_;
@@ -53,7 +53,7 @@ contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @notice Update the Inbox contract reference.
     /// @param inbox_ Address of the new Inbox contract.
     function setInbox(address inbox_) external onlyOwner {
-        require(inbox_ != address(0), ZeroAddress());
+        require(inbox_ != address(0), ZeroAddress("inbox"));
         inbox = inbox_;
         emit InboxSet(inbox_);
     }
@@ -61,7 +61,7 @@ contract BridgeMinter is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable
     /// @notice Update the stablecoin contract reference.
     /// @param stablecoin_ Address of the new stablecoin contract.
     function setStablecoin(address stablecoin_) external onlyOwner {
-        require(stablecoin_ != address(0), ZeroAddress());
+        require(stablecoin_ != address(0), ZeroAddress("stablecoin"));
         stablecoin = Stablecoin(stablecoin_);
         emit StablecoinSet(stablecoin_);
     }

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -47,7 +47,7 @@ contract Inbox is
     error SignerNotAttestor(address signer);
     error NonceAlreadyUsed(bytes32 nonce);
     error WrongDestinationChain(uint256 expected, uint256 actual);
-    error ZeroAddress();
+    error ZeroAddress(bytes32 field);
     error AlreadyAttestor(address attestor);
     error NotAttestor(address attestor);
 
@@ -88,7 +88,7 @@ contract Inbox is
     /// @notice Add an address to the attestor set.
     /// @param attestor Address to add. Must not be zero or already an attestor.
     function addAttestor(address attestor) external onlyOwner {
-        require(attestor != address(0), ZeroAddress());
+        require(attestor != address(0), ZeroAddress("attestor"));
         require(_attestors.add(attestor), AlreadyAttestor(attestor));
         emit AttestorAdded(attestor);
     }

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -1046,6 +1046,42 @@ contract StablecoinTest is Test {
         assertFalse(stablecoin.frozen(account));
     }
 
+    function test_CannotInitializeWithZeroAdmin() public {
+        Stablecoin impl = new Stablecoin();
+        vm.expectRevert("ADMIN_ROLE is zero address");
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, address(0), BURNER, PAUSER, FREEZER))
+        );
+    }
+
+    function test_CannotInitializeWithZeroBurner() public {
+        Stablecoin impl = new Stablecoin();
+        vm.expectRevert("BURNER_ROLE is zero address");
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, ADMIN, address(0), PAUSER, FREEZER))
+        );
+    }
+
+    function test_CannotInitializeWithZeroPauser() public {
+        Stablecoin impl = new Stablecoin();
+        vm.expectRevert("PAUSER_ROLE is zero address");
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, ADMIN, BURNER, address(0), FREEZER))
+        );
+    }
+
+    function test_CannotInitializeWithZeroFreezer() public {
+        Stablecoin impl = new Stablecoin();
+        vm.expectRevert("FREEZER_ROLE is zero address");
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, ADMIN, BURNER, PAUSER, address(0)))
+        );
+    }
+
     function test_ImplementationCannotBeInitialized() public {
         // Deploy a new implementation directly (not through proxy)
         Stablecoin impl = new Stablecoin();

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -1048,7 +1048,7 @@ contract StablecoinTest is Test {
 
     function test_CannotInitializeWithZeroAdmin() public {
         Stablecoin impl = new Stablecoin();
-        vm.expectRevert("ADMIN_ROLE is zero address");
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.ZeroAddress.selector, stablecoin.ADMIN_ROLE()));
         new ERC1967Proxy(
             address(impl),
             abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, address(0), BURNER, PAUSER, FREEZER))
@@ -1057,7 +1057,7 @@ contract StablecoinTest is Test {
 
     function test_CannotInitializeWithZeroBurner() public {
         Stablecoin impl = new Stablecoin();
-        vm.expectRevert("BURNER_ROLE is zero address");
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.ZeroAddress.selector, stablecoin.BURNER_ROLE()));
         new ERC1967Proxy(
             address(impl),
             abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, ADMIN, address(0), PAUSER, FREEZER))
@@ -1066,7 +1066,7 @@ contract StablecoinTest is Test {
 
     function test_CannotInitializeWithZeroPauser() public {
         Stablecoin impl = new Stablecoin();
-        vm.expectRevert("PAUSER_ROLE is zero address");
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.ZeroAddress.selector, stablecoin.PAUSER_ROLE()));
         new ERC1967Proxy(
             address(impl),
             abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, ADMIN, BURNER, address(0), FREEZER))
@@ -1075,7 +1075,7 @@ contract StablecoinTest is Test {
 
     function test_CannotInitializeWithZeroFreezer() public {
         Stablecoin impl = new Stablecoin();
-        vm.expectRevert("FREEZER_ROLE is zero address");
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.ZeroAddress.selector, stablecoin.FREEZER_ROLE()));
         new ERC1967Proxy(
             address(impl),
             abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, ADMIN, BURNER, PAUSER, address(0)))


### PR DESCRIPTION
Stablecoin.initialize previously accepted address(0) as the recipient of any of ADMIN_ROLE, BURNER_ROLE, PAUSER_ROLE, or FREEZER_ROLE. Either a typo or a missing env var in the deploy script would silently "grant" the role to the zero address, leaving the corresponding capability orphaned and the contract in a broken state that may not be recoverable on-chain.