### PR TITLE
replace magic numbers with named constants

### DIFF
--- a/script/DeployTestBridge.s.sol
+++ b/script/DeployTestBridge.s.sol
@@ -11,6 +11,8 @@ import {BridgeMinter} from "src/bridge/BridgeMinter.sol";
 
 /// @notice Deploys all bridge contracts directly (no CREATE2) for integration testing.
 contract DeployTestBridge is Script {
+    uint8 internal constant DECIMALS = 6;
+
     function run(address attestor, uint256 minterAllowance) public {
         address admin = msg.sender;
 
@@ -36,7 +38,8 @@ contract DeployTestBridge is Script {
     function _deployStablecoin(address admin) internal returns (Stablecoin) {
         Stablecoin impl_ = new Stablecoin();
         ERC1967Proxy proxy = new ERC1967Proxy(
-            address(impl_), abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", 6, admin, admin, admin, admin))
+            address(impl_),
+            abi.encodeCall(Stablecoin.initialize, ("Stablecoin", "STBL", DECIMALS, admin, admin, admin, admin))
         );
         return Stablecoin(address(proxy));
     }

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -24,6 +24,9 @@ contract Inbox is
 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
+    /// @notice Length in bytes of a packed ECDSA signature (r || s || v).
+    uint256 internal constant SIGNATURE_LENGTH = 65;
+
     /// @notice Minimum number of valid attestor signatures required.
     uint256 public threshold;
 
@@ -161,16 +164,16 @@ contract Inbox is
 
         // Fail-closed: reject all messages when threshold is unconfigured (zero).
         require(threshold_ > 0, BelowThreshold());
-        uint256 sigCount = signatures.length / 65;
-        require(signatures.length == sigCount * 65, InvalidSignatureCount());
+        uint256 sigCount = signatures.length / SIGNATURE_LENGTH;
+        require(signatures.length == sigCount * SIGNATURE_LENGTH, InvalidSignatureCount());
         require(sigCount >= threshold_, BelowThreshold());
 
         bytes32 digest = _hashMessage(message);
 
         address prevSigner = address(0);
         for (uint256 i = 0; i < sigCount; i++) {
-            uint256 offset = i * 65;
-            address signer = ECDSA.recoverCalldata(digest, signatures[offset:offset + 65]);
+            uint256 offset = i * SIGNATURE_LENGTH;
+            address signer = ECDSA.recoverCalldata(digest, signatures[offset:offset + SIGNATURE_LENGTH]);
 
             // Enforce ascending order to detect duplicates in O(n)
             require(signer > prevSigner, DuplicateSigner());


### PR DESCRIPTION
This PR replaces 2 magic numbers with constants: 

1. Inbox now uses SIGNATURE_LENGTH = 65 across all four sites in the signature-verification loop (length divisor, length validity check, per-iteration offset, calldata slice end), instead of repeating the ECDSA packed-signature length as a bare literal.

(Minor)
2. DeployTestBridge uses DECIMALS = 6 instead of the bare literal in the Stablecoin initialize() call.
