### PR TITLE
Add timelock for Admin rotation and operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,35 @@ jobs:
         # All formal-test contract names end in `FormalTest` (see test/bridge/Bridge.formal.t.sol).
         # Halmos has no `--match-path`, so we scope by contract-name regex instead.
         run: halmos --match-contract 'FormalTest$'
+
+  integration:
+    name: anvil upgrade integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          submodules: recursive
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        with:
+          version: stable
+      # Node + npx are required: the integration script's step-1 forge script
+      # invokes `Upgrades.upgradeProxy(...)` which FFIs to
+      # `npx @openzeppelin/upgrades-core` for storage-layout validation
+      # against the OldStablecoin reference contract.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+      # The script orchestrates the full upgrade flow against a freshly-spawned
+      # anvil instance:
+      #   1. forge clean + forge build (OZ validator needs a full compilation)
+      #   2. spawn anvil and assert chain-id == 31337
+      #   3. step 1 forge script: deploy OldStablecoin proxy, atomic
+      #      upgrade-and-reinit, deploy timelock, schedule addMinter
+      #   4. cast rpc evm_increaseTime past minDelay
+      #   5. step 2 forge script: execute the matured op and assert final state
+      #   6. cleanup (anvil teardown + state-file rm) via EXIT trap
+      # Invoked via `bash` so we don't depend on the executable bit being
+      # preserved through git checkouts on every platform.
+      - name: Run anvil-orchestrated upgrade-from-main integration test
+        run: bash script/integration/run_anvil_integration.sh

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,4 +13,12 @@ optimizer_runs = 200
 cbor_metadata = false
 bytecode_hash = "none"
 ignored_warnings_from = ["lib"]
+# fs_permissions intentionally lists reads broadly (any entry shifts foundry
+# into strict mode, where unlisted paths are *blocked*; OZ Upgrades relies on
+# reading out/ at validation time, so we restore that). The single write
+# permission scopes vm.writeJson to the integration test's state file.
+fs_permissions = [
+    { access = "read", path = "./" },
+    { access = "read-write", path = "./integration-state.json" },
+]
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/script/DeployTimelock.s.sol
+++ b/script/DeployTimelock.s.sol
@@ -2,39 +2,40 @@
 pragma solidity =0.8.30;
 
 import {Script, console} from "forge-std/Script.sol";
-import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {Stablecoin} from "../src/Stablecoin.sol";
+import {StablecoinTimelock} from "../src/StablecoinTimelock.sol";
 
-/// @notice Deploys an OpenZeppelin TimelockController suitable for holding
-/// `ADMIN_ROLE` on the Stablecoin contract. Any ADMIN_ROLE grant or revocation
-/// (including rotation to a new TimelockController) must then be proposed,
-/// wait `minDelay` seconds, and be executed, giving the team a window to
-/// detect and cancel a hostile rotation before it lands on-chain.
+/// @notice Deploys a `StablecoinTimelock` suitable for holding `ADMIN_ROLE` on
+/// the given Stablecoin proxy. The deployed timelock has `address(0)` as its
+/// own admin so it administers itself via timelocked operations (standard OZ
+/// pattern). It is bound at construction to a single Stablecoin and exposes
+/// typed `schedule*` helpers for every ADMIN_ROLE-gated operation.
 ///
 /// `proposers` are the addresses (typically the team multisig) that can
 /// schedule operations; `executors` are the addresses that can execute a
 /// matured operation (use `address(0)` in `executors` to allow anyone — open
 /// execution removes the need for a privileged executor keychain).
 ///
-/// The TimelockController's own admin is left as `address(0)` so that the
-/// timelock administers itself via timelocked operations. This matches the
-/// recommended OpenZeppelin pattern for governance contracts.
-///
 /// Usage:
 ///   forge script script/DeployTimelock.s.sol \
 ///       --broadcast --private-key $DEPLOYER_KEY --rpc-url $RPC_URL \
-///       --sig 'run(uint256,address[],address[])' \
-///       $MIN_DELAY_SECONDS $PROPOSERS_ARRAY $EXECUTORS_ARRAY
+///       --sig 'run(address,uint256,address[],address[])' \
+///       $STABLECOIN $MIN_DELAY_SECONDS $PROPOSERS_ARRAY $EXECUTORS_ARRAY
 ///
-/// The deployed address can then be passed as `admin` to DeployStablecoin.s.sol.
+/// The deployed timelock address can then be passed as `admin` to
+/// DeployStablecoin.s.sol (fresh stablecoin), or granted ADMIN_ROLE from the
+/// current admin (already-deployed stablecoin).
 contract DeployTimelock is Script {
-    function run(uint256 minDelay, address[] memory proposers, address[] memory executors) public {
+    function run(address stablecoin, uint256 minDelay, address[] memory proposers, address[] memory executors) public {
+        require(stablecoin != address(0), "DeployTimelock: stablecoin == address(0)");
+
         vm.startBroadcast();
-        // admin = address(0) means the timelock is its own admin; rotations of
-        // the proposer/executor sets must be timelocked.
-        TimelockController timelock = new TimelockController(minDelay, proposers, executors, address(0));
+        StablecoinTimelock timelock =
+            new StablecoinTimelock(Stablecoin(stablecoin), minDelay, proposers, executors, address(0));
         vm.stopBroadcast();
 
-        console.log("TimelockController deployed at:", address(timelock));
+        console.log("StablecoinTimelock deployed at:", address(timelock));
+        console.log("Bound stablecoin:", stablecoin);
         console.log("Min delay (seconds):", minDelay);
         console.log("Proposer count:", proposers.length);
         console.log("Executor count (0 means open execution):", executors.length);

--- a/script/DeployTimelock.s.sol
+++ b/script/DeployTimelock.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
 import {Script, console} from "forge-std/Script.sol";

--- a/script/DeployTimelock.s.sol
+++ b/script/DeployTimelock.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.30;
+
+import {Script, console} from "forge-std/Script.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/// @notice Deploys an OpenZeppelin TimelockController suitable for holding
+/// `ADMIN_ROLE` on the Stablecoin contract. Any ADMIN_ROLE grant or revocation
+/// (including rotation to a new TimelockController) must then be proposed,
+/// wait `minDelay` seconds, and be executed, giving the team a window to
+/// detect and cancel a hostile rotation before it lands on-chain.
+///
+/// `proposers` are the addresses (typically the team multisig) that can
+/// schedule operations; `executors` are the addresses that can execute a
+/// matured operation (use `address(0)` in `executors` to allow anyone — open
+/// execution removes the need for a privileged executor keychain).
+///
+/// The TimelockController's own admin is left as `address(0)` so that the
+/// timelock administers itself via timelocked operations. This matches the
+/// recommended OpenZeppelin pattern for governance contracts.
+///
+/// Usage:
+///   forge script script/DeployTimelock.s.sol \
+///       --broadcast --private-key $DEPLOYER_KEY --rpc-url $RPC_URL \
+///       --sig 'run(uint256,address[],address[])' \
+///       $MIN_DELAY_SECONDS $PROPOSERS_ARRAY $EXECUTORS_ARRAY
+///
+/// The deployed address can then be passed as `admin` to DeployStablecoin.s.sol.
+contract DeployTimelock is Script {
+    function run(uint256 minDelay, address[] memory proposers, address[] memory executors) public {
+        vm.startBroadcast();
+        // admin = address(0) means the timelock is its own admin; rotations of
+        // the proposer/executor sets must be timelocked.
+        TimelockController timelock = new TimelockController(minDelay, proposers, executors, address(0));
+        vm.stopBroadcast();
+
+        console.log("TimelockController deployed at:", address(timelock));
+        console.log("Min delay (seconds):", minDelay);
+        console.log("Proposer count:", proposers.length);
+        console.log("Executor count (0 means open execution):", executors.length);
+    }
+}

--- a/script/integration/IntegrationDeployAndSchedule.s.sol
+++ b/script/integration/IntegrationDeployAndSchedule.s.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.30;
+
+import {Script, console} from "forge-std/Script.sol";
+import {Upgrades, Options} from "@openzeppelin-foundry-upgrades/Upgrades.sol";
+import {Stablecoin} from "../../src/Stablecoin.sol";
+import {StablecoinTimelock} from "../../src/StablecoinTimelock.sol";
+import {OldStablecoin} from "./OldStablecoin.sol";
+
+/// @notice Step 1 of the upgrade integration test, designed to mirror what a
+/// real operator would run against mainnet.
+///
+/// Deliberately uses the same OpenZeppelin Foundry Upgrades plumbing as
+/// `script/DeployStablecoin.s.sol` and `script/UpgradeStablecoin.s.sol`, so
+/// the test exercises the same storage-layout safety checks the production
+/// scripts rely on.
+///
+/// Sequence:
+///   1. `Upgrades.deployUUPSProxy("OldStablecoin.sol", …)` — deploys the
+///      pre-M-01 implementation and an ERC1967 proxy initialized to it. This
+///      is identical to how a mainnet stablecoin from `main` was originally
+///      deployed.
+///   2. Sanity: `addMinter` works via the deployer on the *old* contract.
+///   3. `Upgrades.upgradeProxy(proxy, "Stablecoin.sol", reinitData, opts)`
+///      with `opts.referenceContract = "OldStablecoin.sol"`. OZ validates the
+///      new contract's storage layout against the old one before calling
+///      `upgradeToAndCall(newImpl, reinitData)` on the proxy. `reinitData`
+///      is `abi.encodeCall(Stablecoin.reinitializeAdminRole, ())` so the slot
+///      repair happens atomically with the implementation flip.
+///   4. Verify the role-admin storage slot is now self-administering.
+///   5. Deploy `StablecoinTimelock` bound to the proxy. `minDelay = 60s`
+///      (small for test speed; production should pick 48h+).
+///   6. Grant `ADMIN_ROLE` to the timelock. Deployer keeps admin too, so the
+///      `_revokeRole` empty-admin guard isn't relevant for the test.
+///   7. Schedule `addMinter(beef, 5000e18)` via the timelock.
+///
+/// State (proxy, timelock, op params) is serialized to
+/// `./integration-state.json` for step 2 (`IntegrationExecuteAndVerify`).
+contract IntegrationDeployAndSchedule is Script {
+    uint256 internal constant MIN_DELAY = 60;
+    address internal constant NEW_MINTER = address(0xBEEF);
+    uint256 internal constant NEW_CAP = 5_000e18;
+    bytes32 internal constant SALT = bytes32(uint256(0xDEADBEEF));
+
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+
+        vm.startBroadcast(deployerKey);
+
+        // 1. Deploy OldStablecoin behind a UUPS proxy via the OZ helper. This
+        //    matches script/DeployStablecoin.s.sol exactly so the integration
+        //    test produces the same on-chain shape a real operator would.
+        bytes memory initData = abi.encodeCall(
+            OldStablecoin.initialize, ("Test Stablecoin", "TSC", 18, deployer, deployer, deployer, deployer)
+        );
+        address proxyAddr = Upgrades.deployUUPSProxy("OldStablecoin.sol", initData);
+        OldStablecoin oldProxy = OldStablecoin(proxyAddr);
+
+        // 2. Sanity check on the old impl.
+        oldProxy.addMinter(address(0xCAFE), 100e18);
+        require(oldProxy.hasRole(oldProxy.MINTER_ROLE(), address(0xCAFE)), "old addMinter failed");
+
+        // 3. Atomic upgrade + reinit via the OZ helper. With
+        //    `referenceContract` set, OZ runs its storage-layout validator on
+        //    OldStablecoin → Stablecoin before issuing the upgrade tx. If the
+        //    layouts were incompatible, this would revert at simulation time
+        //    — exactly the safety net we want operators to have on mainnet.
+        bytes memory reinitData = abi.encodeCall(Stablecoin.reinitializeAdminRole, ());
+        Options memory opts;
+        opts.referenceContract = "OldStablecoin.sol";
+        Upgrades.upgradeProxy(proxyAddr, "Stablecoin.sol", reinitData, opts);
+
+        Stablecoin upgraded = Stablecoin(proxyAddr);
+
+        // 4. The slot that `main`'s initialize never set is now self-administering.
+        require(upgraded.getRoleAdmin(upgraded.ADMIN_ROLE()) == upgraded.ADMIN_ROLE(), "role admin not repaired");
+
+        // 5. Deploy the timelock with open execution (executor = address(0)).
+        address[] memory proposers = new address[](1);
+        proposers[0] = deployer;
+        address[] memory executors = new address[](1);
+        executors[0] = address(0);
+        StablecoinTimelock timelock = new StablecoinTimelock(upgraded, MIN_DELAY, proposers, executors, address(0));
+
+        // 6. Hand admin to the timelock. Deployer also retains the role so we
+        //    don't have to detour through the timelock for the test itself.
+        upgraded.grantRole(upgraded.ADMIN_ROLE(), address(timelock));
+        require(upgraded.hasRole(upgraded.ADMIN_ROLE(), address(timelock)), "timelock not granted admin");
+
+        // 7. Schedule an addMinter through the timelock's typed helper.
+        timelock.scheduleAddMinter(NEW_MINTER, NEW_CAP, SALT, MIN_DELAY);
+
+        vm.stopBroadcast();
+
+        // Hand off state to step 2.
+        string memory json = "integration";
+        vm.serializeAddress(json, "proxy", proxyAddr);
+        vm.serializeAddress(json, "timelock", address(timelock));
+        vm.serializeAddress(json, "newMinter", NEW_MINTER);
+        vm.serializeUint(json, "newCap", NEW_CAP);
+        vm.serializeBytes32(json, "salt", SALT);
+        string memory out = vm.serializeUint(json, "minDelay", MIN_DELAY);
+        vm.writeJson(out, "./integration-state.json");
+
+        console.log("=== IntegrationDeployAndSchedule complete ===");
+        console.log("proxy:    ", proxyAddr);
+        console.log("timelock: ", address(timelock));
+        console.log("newMinter:", NEW_MINTER);
+        console.log("newCap:   ", NEW_CAP);
+        console.log("minDelay: ", MIN_DELAY);
+    }
+}

--- a/script/integration/IntegrationDeployAndSchedule.s.sol
+++ b/script/integration/IntegrationDeployAndSchedule.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
 import {Script, console} from "forge-std/Script.sol";

--- a/script/integration/IntegrationExecuteAndVerify.s.sol
+++ b/script/integration/IntegrationExecuteAndVerify.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
 import {Script, console} from "forge-std/Script.sol";

--- a/script/integration/IntegrationExecuteAndVerify.s.sol
+++ b/script/integration/IntegrationExecuteAndVerify.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.30;
+
+import {Script, console} from "forge-std/Script.sol";
+import {Stablecoin} from "../../src/Stablecoin.sol";
+import {StablecoinTimelock} from "../../src/StablecoinTimelock.sol";
+
+/// @notice Step 2 of the upgrade integration test.
+///
+/// Reads `./integration-state.json` written by `IntegrationDeployAndSchedule`,
+/// executes the matured `addMinter` operation through the timelock, and
+/// asserts the final on-chain state. The bash orchestrator advances anvil's
+/// clock past `minDelay` between step 1 and step 2 via `cast rpc
+/// evm_increaseTime`.
+contract IntegrationExecuteAndVerify is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+
+        string memory state = vm.readFile("./integration-state.json");
+        address proxyAddr = vm.parseJsonAddress(state, ".proxy");
+        address timelockAddr = vm.parseJsonAddress(state, ".timelock");
+        address newMinter = vm.parseJsonAddress(state, ".newMinter");
+        uint256 newCap = vm.parseJsonUint(state, ".newCap");
+        bytes32 salt = vm.parseJsonBytes32(state, ".salt");
+
+        Stablecoin sc = Stablecoin(proxyAddr);
+        StablecoinTimelock tl = StablecoinTimelock(payable(timelockAddr));
+
+        vm.startBroadcast(deployerKey);
+
+        // Reconstruct the same calldata the typed helper scheduled.
+        bytes memory data = abi.encodeCall(Stablecoin.addMinter, (newMinter, newCap));
+        tl.execute(proxyAddr, 0, data, bytes32(0), salt);
+
+        vm.stopBroadcast();
+
+        // Post-conditions: minter role granted with the expected allowance,
+        // and admin set unchanged from step 1 (deployer + timelock, count 2).
+        require(sc.hasRole(sc.MINTER_ROLE(), newMinter), "MINTER_ROLE not granted to newMinter");
+        require(sc.minterAllowance(newMinter) == newCap, "minter allowance mismatch");
+        require(sc.getRoleMemberCount(sc.ADMIN_ROLE()) == 2, "unexpected admin set size");
+        require(sc.hasRole(sc.ADMIN_ROLE(), timelockAddr), "timelock lost ADMIN_ROLE");
+
+        console.log("=== IntegrationExecuteAndVerify PASSED ===");
+        console.log("MINTER_ROLE holder:", newMinter);
+        console.log("allowance:         ", sc.minterAllowance(newMinter));
+        console.log("admin set size:    ", sc.getRoleMemberCount(sc.ADMIN_ROLE()));
+    }
+}

--- a/script/integration/OldStablecoin.sol
+++ b/script/integration/OldStablecoin.sol
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
-// TODO: add the right license
 pragma solidity =0.8.30;
+
+// ============================================================================
+// INTEGRATION-TEST FIXTURE — NOT FOR PRODUCTION DEPLOYMENT
+//
+// Verbatim snapshot of `src/Stablecoin.sol` at branch `main` (commit 1950819),
+// renamed to `OldStablecoin` so the integration script can deploy a proxy at
+// the *pre-M-01* implementation and then upgrade it to the fixed version in
+// `src/Stablecoin.sol`. Exercises the real upgrade migration path operators
+// will follow on an already-deployed mainnet proxy.
+//
+// DO NOT import this file from `src/`. Only the integration script under
+// `script/integration/` references it.
+// ============================================================================
 
 import {
     ERC20BurnableUpgradeable
@@ -16,24 +28,12 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
- * @title Stablecoin
- * @dev Upgradeable ERC20 stablecoin with role-based access control.
- *
- * Roles:
- *  - ADMIN_ROLE: Manages minters and their allowances, authorizes upgrades, and
- *    administers itself (can grant or revoke ADMIN_ROLE on other accounts).
- *    For production deployments, the holder of ADMIN_ROLE MUST be an OpenZeppelin
- *    `TimelockController` (or equivalent delayed-execution governance contract);
- *    direct EOAs or unsynchronized multisigs SHOULD NOT hold ADMIN_ROLE because the
- *    role is self-administering and any rotation, grant, or revocation runs
- *    immediately.
- *  - MINTER_ROLE: Can mint tokens up to an individual allowance. Managed exclusively
- *    through addMinter/removeMinter to keep role and allowance state in sync.
- *  - BURNER_ROLE: Can burn tokens from own balance or via allowance (burnFrom).
- *  - PAUSER_ROLE: Can pause/unpause all token operations.
- *  - FREEZER_ROLE: Can freeze/unfreeze individual accounts.
+ * @title OldStablecoin
+ * @dev Pre-M-01 Stablecoin (snapshot from main). Used only by the integration
+ * upgrade script to model an already-deployed proxy. See banner at top of
+ * file.
  */
-contract Stablecoin is
+contract OldStablecoin is
     Initializable,
     ERC20Upgradeable,
     ERC20BurnableUpgradeable,
@@ -65,12 +65,6 @@ contract Stablecoin is
     event AccountFrozen(address indexed account);
     event AccountUnfrozen(address indexed account);
 
-    /// @dev Reverts when a revoke or renounce of ADMIN_ROLE would empty the
-    /// admin set. ADMIN_ROLE is self-administering, so a zero-member admin set
-    /// is unrecoverable on-chain: minter management, role rotation, and UUPS
-    /// upgrade authorization all become permanently unreachable.
-    error AdminRoleCannotBeEmpty();
-
     modifier whenNotFrozen(address account) {
         _whenNotFrozen(account);
         _;
@@ -95,15 +89,6 @@ contract Stablecoin is
      * making grantRole/revokeRole for MINTER_ROLE always revert. The only way to
      * manage minters is through addMinter/removeMinter, which atomically update both
      * the role and the allowance, preventing state divergence between the two.
-     *
-     * @dev ADMIN_ROLE is configured as its own admin so that an existing admin can
-     * rotate the role on-chain (grant ADMIN_ROLE to a new account, revoke it from
-     * an old one). Because the role is self-administering and grants/revocations
-     * are immediate, the recommended `admin` value at initialize-time is an
-     * OpenZeppelin `TimelockController` deployed via `script/DeployTimelock.s.sol`.
-     * Routing rotations through a timelock gives the team a delay window to detect
-     * and cancel a hostile rotation before it executes. Revoking or renouncing the
-     * last remaining admin reverts (see `_revokeRole`).
      */
     function initialize(
         string memory name,
@@ -123,7 +108,6 @@ contract Stablecoin is
         _decimals = decimals_;
 
         // MINTER_ROLE intentionally not listed here — see @dev note above.
-        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(BURNER_ROLE, ADMIN_ROLE);
         _setRoleAdmin(PAUSER_ROLE, ADMIN_ROLE);
         _setRoleAdmin(FREEZER_ROLE, ADMIN_ROLE);
@@ -131,22 +115,6 @@ contract Stablecoin is
         _grantRole(BURNER_ROLE, burner);
         _grantRole(PAUSER_ROLE, pauser);
         _grantRole(FREEZER_ROLE, freezer);
-    }
-
-    /// @notice One-time storage-slot repair for proxies that were initialized
-    /// under a prior implementation where `_setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE)`
-    /// was never called. Sets `ADMIN_ROLE` as its own admin so the current
-    /// admin can rotate the role (M-01).
-    ///
-    /// @dev Gated by `reinitializer(2)` so it can run at most once per proxy,
-    /// and by `onlyRole(ADMIN_ROLE)` so only the legitimate admin can trigger
-    /// the repair. On a freshly-deployed proxy the call is a no-op (the new
-    /// `initialize` already sets the same value); on an upgraded proxy it
-    /// repairs the previously-unset slot. Intended call sites:
-    ///   proxy.upgradeToAndCall(newImpl, abi.encodeCall(this.reinitializeAdminRole, ()))
-    /// so the upgrade and the storage repair happen atomically.
-    function reinitializeAdminRole() public reinitializer(2) onlyRole(ADMIN_ROLE) {
-        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
     }
 
     function decimals() public view override returns (uint8) {
@@ -282,19 +250,5 @@ contract Stablecoin is
 
     function _whenNotFrozen(address account) internal view {
         require(!frozen[account], "Frozen account");
-    }
-
-    /// @dev Centralized revoke hook for both `revokeRole` and `renounceRole`.
-    /// Refuses to remove the last remaining holder of ADMIN_ROLE, since ADMIN_ROLE
-    /// is its own admin (a zero-admin state is unrecoverable on-chain).
-    function _revokeRole(bytes32 role, address account)
-        internal
-        override(AccessControlEnumerableUpgradeable)
-        returns (bool)
-    {
-        if (role == ADMIN_ROLE && hasRole(ADMIN_ROLE, account) && getRoleMemberCount(ADMIN_ROLE) == 1) {
-            revert AdminRoleCannotBeEmpty();
-        }
-        return super._revokeRole(role, account);
     }
 }

--- a/script/integration/OldStablecoin.sol
+++ b/script/integration/OldStablecoin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
 // ============================================================================

--- a/script/integration/run_anvil_integration.sh
+++ b/script/integration/run_anvil_integration.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Integration test: deploy main's Stablecoin, upgrade to this branch's
+# version, hand admin to StablecoinTimelock, and execute a scheduled
+# addMinter through the timelock. Runs against a freshly-spawned anvil.
+#
+# Usage: ./script/integration/run_anvil_integration.sh
+#
+# Exits non-zero on any step failure. Requires `anvil`, `cast`, and `forge`
+# on PATH (all part of a standard foundry install).
+
+set -euo pipefail
+
+# Anvil's well-known dev account #0 — never use this on a public network.
+DEPLOYER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+RPC_URL="http://127.0.0.1:8545"
+STATE_FILE="./integration-state.json"
+MIN_DELAY=60
+TIME_ADVANCE=$((MIN_DELAY + 10))
+EXPECTED_CHAIN_ID=31337  # anvil default — refuse to run against anything else
+
+# Project root is two levels up from this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/../.."
+
+ANVIL_PID=""
+cleanup() {
+    if [[ -n "$ANVIL_PID" ]] && kill -0 "$ANVIL_PID" 2>/dev/null; then
+        kill "$ANVIL_PID" 2>/dev/null || true
+        wait "$ANVIL_PID" 2>/dev/null || true
+    fi
+    rm -f "$STATE_FILE"
+}
+trap cleanup EXIT
+
+# Refuse to start if port 8545 already has something listening — otherwise we'd
+# silently piggy-back on someone else's anvil (or worse) and produce misleading
+# results.
+if cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1; then
+    echo "ERROR: something is already listening on $RPC_URL — refusing to start anvil." >&2
+    echo "       Stop the existing process (or use a different RPC_URL) and re-run." >&2
+    exit 1
+fi
+
+# The OZ Upgrades library validates storage layout via @openzeppelin/upgrades-core,
+# which insists on a *full* compilation (no incremental build-info). Without
+# this, step 1's `Upgrades.upgradeProxy(...)` aborts at the validator with:
+#   "Build info file out/build-info/<hash>.json is not from a full compilation."
+echo "==> forge clean + build (required by OZ Upgrades validator)..."
+forge clean
+forge build >/dev/null
+
+echo "==> Starting anvil (silent)..."
+anvil --silent >/dev/null 2>&1 &
+ANVIL_PID=$!
+
+# Wait for anvil's JSON-RPC to be ready. cast block-number is the cheapest probe.
+# Bail out early if the anvil process itself died — otherwise we'd loop on a
+# dead PID and then fail with a confusing connection error.
+for i in {1..50}; do
+    if ! kill -0 "$ANVIL_PID" 2>/dev/null; then
+        echo "ERROR: anvil process exited before becoming ready (pid $ANVIL_PID)" >&2
+        exit 1
+    fi
+    if cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+if ! cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1; then
+    echo "ERROR: anvil did not become ready within 5s" >&2
+    exit 1
+fi
+
+# Belt-and-braces: if anvil happened to start but somehow we're talking to a
+# different process (e.g. a stale node we missed on the pre-flight check),
+# `cast chain-id` will tell us. Refuse anything other than anvil's default.
+ACTUAL_CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL")"
+if [[ "$ACTUAL_CHAIN_ID" != "$EXPECTED_CHAIN_ID" ]]; then
+    echo "ERROR: connected RPC reports chain id $ACTUAL_CHAIN_ID, expected $EXPECTED_CHAIN_ID." >&2
+    echo "       This script uses a hardcoded dev key and must only run against anvil." >&2
+    exit 1
+fi
+echo "==> anvil ready (pid $ANVIL_PID, chain id $ACTUAL_CHAIN_ID)"
+
+echo
+echo "==> Step 1/3: deploy old impl, upgrade to new, set up timelock, schedule addMinter"
+PRIVATE_KEY="$DEPLOYER_KEY" forge script \
+    script/integration/IntegrationDeployAndSchedule.s.sol:IntegrationDeployAndSchedule \
+    --rpc-url "$RPC_URL" \
+    --broadcast \
+    --slow \
+    -vv
+
+echo
+echo "==> Step 2/3: advance anvil time by ${TIME_ADVANCE}s (min delay = ${MIN_DELAY}s)"
+cast rpc evm_increaseTime "$TIME_ADVANCE" --rpc-url "$RPC_URL" >/dev/null
+cast rpc evm_mine --rpc-url "$RPC_URL" >/dev/null
+
+echo
+echo "==> Step 3/3: execute matured operation through timelock and verify"
+PRIVATE_KEY="$DEPLOYER_KEY" forge script \
+    script/integration/IntegrationExecuteAndVerify.s.sol:IntegrationExecuteAndVerify \
+    --rpc-url "$RPC_URL" \
+    --broadcast \
+    --slow \
+    -vv
+
+echo
+echo "==> Integration test PASSED"

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -20,7 +20,13 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
  * @dev Upgradeable ERC20 stablecoin with role-based access control.
  *
  * Roles:
- *  - ADMIN_ROLE: Manages minters and their allowances, authorizes upgrades.
+ *  - ADMIN_ROLE: Manages minters and their allowances, authorizes upgrades, and
+ *    administers itself (can grant or revoke ADMIN_ROLE on other accounts).
+ *    For production deployments, the holder of ADMIN_ROLE MUST be an OpenZeppelin
+ *    `TimelockController` (or equivalent delayed-execution governance contract);
+ *    direct EOAs or unsynchronized multisigs SHOULD NOT hold ADMIN_ROLE because the
+ *    role is self-administering and any rotation, grant, or revocation runs
+ *    immediately.
  *  - MINTER_ROLE: Can mint tokens up to an individual allowance. Managed exclusively
  *    through addMinter/removeMinter to keep role and allowance state in sync.
  *  - BURNER_ROLE: Can burn tokens from own balance or via allowance (burnFrom).
@@ -59,6 +65,11 @@ contract Stablecoin is
     event AccountFrozen(address indexed account);
     event AccountUnfrozen(address indexed account);
 
+    /// @dev Reverts when a revoke / renounce of ADMIN_ROLE would leave the contract
+    /// with zero admins. Without at least one admin, minter management and UUPS
+    /// upgrades become permanently unreachable on-chain.
+    error LastAdminCannotBeRemoved();
+
     modifier whenNotFrozen(address account) {
         _whenNotFrozen(account);
         _;
@@ -83,6 +94,15 @@ contract Stablecoin is
      * making grantRole/revokeRole for MINTER_ROLE always revert. The only way to
      * manage minters is through addMinter/removeMinter, which atomically update both
      * the role and the allowance, preventing state divergence between the two.
+     *
+     * @dev ADMIN_ROLE is configured as its own admin so that an existing admin can
+     * rotate the role on-chain (grant ADMIN_ROLE to a new account, revoke it from
+     * an old one). Because the role is self-administering and grants/revocations
+     * are immediate, the recommended `admin` value at initialize-time is an
+     * OpenZeppelin `TimelockController` deployed via `script/DeployTimelock.s.sol`.
+     * Routing rotations through a timelock gives the team a delay window to detect
+     * and cancel a hostile rotation before it executes. Revoking or renouncing the
+     * last remaining admin reverts (see `_revokeRole`).
      */
     function initialize(
         string memory name,
@@ -102,6 +122,7 @@ contract Stablecoin is
         _decimals = decimals_;
 
         // MINTER_ROLE intentionally not listed here — see @dev note above.
+        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(BURNER_ROLE, ADMIN_ROLE);
         _setRoleAdmin(PAUSER_ROLE, ADMIN_ROLE);
         _setRoleAdmin(FREEZER_ROLE, ADMIN_ROLE);
@@ -244,5 +265,19 @@ contract Stablecoin is
 
     function _whenNotFrozen(address account) internal view {
         require(!frozen[account], "Frozen account");
+    }
+
+    /// @dev Centralized revoke hook for both `revokeRole` and `renounceRole`.
+    /// Refuses to remove the last remaining holder of ADMIN_ROLE, since ADMIN_ROLE
+    /// is its own admin (a zero-admin state is unrecoverable on-chain).
+    function _revokeRole(bytes32 role, address account)
+        internal
+        override(AccessControlEnumerableUpgradeable)
+        returns (bool)
+    {
+        if (role == ADMIN_ROLE && hasRole(ADMIN_ROLE, account) && getRoleMemberCount(ADMIN_ROLE) == 1) {
+            revert LastAdminCannotBeRemoved();
+        }
+        return super._revokeRole(role, account);
     }
 }

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -65,10 +65,11 @@ contract Stablecoin is
     event AccountFrozen(address indexed account);
     event AccountUnfrozen(address indexed account);
 
-    /// @dev Reverts when a revoke / renounce of ADMIN_ROLE would leave the contract
-    /// with zero admins. Without at least one admin, minter management and UUPS
-    /// upgrades become permanently unreachable on-chain.
-    error LastAdminCannotBeRemoved();
+    /// @dev Reverts when a revoke or renounce of ADMIN_ROLE would empty the
+    /// admin set. ADMIN_ROLE is self-administering, so a zero-member admin set
+    /// is unrecoverable on-chain: minter management, role rotation, and UUPS
+    /// upgrade authorization all become permanently unreachable.
+    error AdminRoleCannotBeEmpty();
 
     modifier whenNotFrozen(address account) {
         _whenNotFrozen(account);
@@ -276,7 +277,7 @@ contract Stablecoin is
         returns (bool)
     {
         if (role == ADMIN_ROLE && hasRole(ADMIN_ROLE, account) && getRoleMemberCount(ADMIN_ROLE) == 1) {
-            revert LastAdminCannotBeRemoved();
+            revert AdminRoleCannotBeEmpty();
         }
         return super._revokeRole(role, account);
     }

--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -71,6 +71,21 @@ contract Stablecoin is
     /// upgrade authorization all become permanently unreachable.
     error AdminRoleCannotBeEmpty();
 
+    /// @dev Reverts when a revoke or renounce of ADMIN_ROLE targets an address
+    /// that does not currently hold the role. Without this guard, OZ's
+    /// `_revokeRole` returns `false` silently with no event — indistinguishable
+    /// from success at the caller. Critical for timelock-gated revocations
+    /// where the operator would otherwise burn the `minDelay` window only to
+    /// discover the revoke was a no-op on a typo'd address.
+    error NotAnAdmin(address account);
+
+    /// @dev Reverts when `_authorizeUpgrade` is reached with an implementation
+    /// address that has no bytecode. UUPSUpgradeable's `proxiableUUID` staticcall
+    /// would also fail downstream, but this earlier check produces a typed
+    /// revert and closes the path where a raw timelock `schedule(...)` call
+    /// bypasses the timelock helper's input validation.
+    error NotAContract(address impl);
+
     modifier whenNotFrozen(address account) {
         _whenNotFrozen(account);
         _;
@@ -278,22 +293,31 @@ contract Stablecoin is
     }
 
     /// @dev UUPS upgrade authorization — only ADMIN_ROLE can upgrade the implementation.
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(ADMIN_ROLE) {}
+    /// Also rejects non-contract implementations so a fat-fingered EOA or
+    /// `address(0)` cannot reach the `proxiableUUID` step (closes the raw
+    /// `timelock.schedule(...)` bypass of `StablecoinTimelock.scheduleUpgrade`).
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(ADMIN_ROLE) {
+        if (newImplementation.code.length == 0) revert NotAContract(newImplementation);
+    }
 
     function _whenNotFrozen(address account) internal view {
         require(!frozen[account], "Frozen account");
     }
 
     /// @dev Centralized revoke hook for both `revokeRole` and `renounceRole`.
-    /// Refuses to remove the last remaining holder of ADMIN_ROLE, since ADMIN_ROLE
-    /// is its own admin (a zero-admin state is unrecoverable on-chain).
+    /// For ADMIN_ROLE: rejects revocations targeting a non-holder (closes OZ's
+    /// silent-no-op path, which would otherwise mask a typo'd address after a
+    /// matured timelock window) and refuses to remove the last remaining
+    /// holder (ADMIN_ROLE is its own admin, so a zero-admin state is
+    /// unrecoverable on-chain). For other roles, behaves like OZ.
     function _revokeRole(bytes32 role, address account)
         internal
         override(AccessControlEnumerableUpgradeable)
         returns (bool)
     {
-        if (role == ADMIN_ROLE && hasRole(ADMIN_ROLE, account) && getRoleMemberCount(ADMIN_ROLE) == 1) {
-            revert AdminRoleCannotBeEmpty();
+        if (role == ADMIN_ROLE) {
+            if (!hasRole(ADMIN_ROLE, account)) revert NotAnAdmin(account);
+            if (getRoleMemberCount(ADMIN_ROLE) == 1) revert AdminRoleCannotBeEmpty();
         }
         return super._revokeRole(role, account);
     }

--- a/src/StablecoinTimelock.sol
+++ b/src/StablecoinTimelock.sol
@@ -43,6 +43,16 @@ contract StablecoinTimelock is TimelockController {
     /// `_revokeRole` would silently return `false` at execute time after the
     /// `minDelay` window had already elapsed.
     error NotAnAdmin(address account);
+    /// @dev `scheduleRevokeBurner` was called with an address that does not hold
+    /// `BURNER_ROLE`. See `scheduleRevokeBurner` for why this guard matters and
+    /// how it differs from the admin path.
+    error NotABurner(address account);
+    /// @dev `scheduleRevokePauser` was called with an address that does not hold
+    /// `PAUSER_ROLE`. See `scheduleRevokeBurner` for the shared rationale.
+    error NotAPauser(address account);
+    /// @dev `scheduleRevokeFreezer` was called with an address that does not hold
+    /// `FREEZER_ROLE`. See `scheduleRevokeBurner` for the shared rationale.
+    error NotAFreezer(address account);
 
     constructor(
         Stablecoin stablecoin_,
@@ -80,6 +90,63 @@ contract StablecoinTimelock is TimelockController {
     function scheduleRevokeAdmin(address oldAdmin, bytes32 salt, uint256 delay) external {
         if (!stablecoin.hasRole(stablecoin.ADMIN_ROLE(), oldAdmin)) revert NotAnAdmin(oldAdmin);
         bytes memory data = abi.encodeCall(stablecoin.revokeRole, (stablecoin.ADMIN_ROLE(), oldAdmin));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `grantRole(BURNER_ROLE, account)` on the bound stablecoin.
+    /// @dev `BURNER_ROLE`'s role admin is `ADMIN_ROLE`, which this timelock holds,
+    /// so the matured operation is authorized at execute time.
+    function scheduleGrantBurner(address account, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.grantRole, (stablecoin.BURNER_ROLE(), account));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `revokeRole(BURNER_ROLE, account)` on the bound stablecoin.
+    /// @dev Rejects `account` values that do not currently hold `BURNER_ROLE`, for
+    /// the same reason as `scheduleRevokeAdmin`: OZ's `_revokeRole` silently no-ops
+    /// on a non-holder, so without this guard a typo'd address would burn the full
+    /// `minDelay` window before failing to do anything at execute time.
+    ///
+    /// Unlike `ADMIN_ROLE`, `Stablecoin._revokeRole` applies no extra guard to
+    /// `BURNER_ROLE`, so this schedule-time check is the *only* line of defense —
+    /// a proposer bypassing the helper via raw `schedule(...)` would still hit the
+    /// silent no-op at execute time. There is likewise no last-holder guard, so
+    /// revoking the sole burner is permitted.
+    function scheduleRevokeBurner(address account, bytes32 salt, uint256 delay) external {
+        if (!stablecoin.hasRole(stablecoin.BURNER_ROLE(), account)) revert NotABurner(account);
+        bytes memory data = abi.encodeCall(stablecoin.revokeRole, (stablecoin.BURNER_ROLE(), account));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `grantRole(PAUSER_ROLE, account)` on the bound stablecoin.
+    /// @dev `PAUSER_ROLE`'s role admin is `ADMIN_ROLE`, which this timelock holds.
+    function scheduleGrantPauser(address account, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.grantRole, (stablecoin.PAUSER_ROLE(), account));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `revokeRole(PAUSER_ROLE, account)` on the bound stablecoin.
+    /// @dev Rejects non-holders at schedule time; see `scheduleRevokeBurner` for the
+    /// rationale and the admin-path asymmetry that applies identically here.
+    function scheduleRevokePauser(address account, bytes32 salt, uint256 delay) external {
+        if (!stablecoin.hasRole(stablecoin.PAUSER_ROLE(), account)) revert NotAPauser(account);
+        bytes memory data = abi.encodeCall(stablecoin.revokeRole, (stablecoin.PAUSER_ROLE(), account));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `grantRole(FREEZER_ROLE, account)` on the bound stablecoin.
+    /// @dev `FREEZER_ROLE`'s role admin is `ADMIN_ROLE`, which this timelock holds.
+    function scheduleGrantFreezer(address account, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.grantRole, (stablecoin.FREEZER_ROLE(), account));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `revokeRole(FREEZER_ROLE, account)` on the bound stablecoin.
+    /// @dev Rejects non-holders at schedule time; see `scheduleRevokeBurner` for the
+    /// rationale and the admin-path asymmetry that applies identically here.
+    function scheduleRevokeFreezer(address account, bytes32 salt, uint256 delay) external {
+        if (!stablecoin.hasRole(stablecoin.FREEZER_ROLE(), account)) revert NotAFreezer(account);
+        bytes memory data = abi.encodeCall(stablecoin.revokeRole, (stablecoin.FREEZER_ROLE(), account));
         _scheduleStablecoinCall(data, salt, delay);
     }
 

--- a/src/StablecoinTimelock.sol
+++ b/src/StablecoinTimelock.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.30;
+
+import {Stablecoin} from "./Stablecoin.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/// @custom:security-contact security@lambdaclass.com
+/// @title StablecoinTimelock
+/// @notice An OpenZeppelin `TimelockController` bound to a single `Stablecoin`
+/// instance, exposing typed `schedule*` helpers for every operation gated by
+/// the stablecoin's `ADMIN_ROLE`. The helpers build calldata internally; raw
+/// `schedule(...)` remains available for any other target.
+///
+/// @dev Helpers route through `Address.functionDelegateCall(address(this), ...)`
+/// because OZ's `schedule(...)` takes `bytes calldata` and its `_schedule`
+/// internal hook is `private`, so memory-encoded payloads cannot be forwarded
+/// directly. Self-delegatecall preserves `msg.sender`, so the inherited
+/// `onlyRole(PROPOSER_ROLE)` check on `schedule` still validates against the
+/// original caller of the helper.
+contract StablecoinTimelock is TimelockController {
+    /// @notice The stablecoin this timelock is bound to. Set at construction
+    /// and not changeable thereafter.
+    Stablecoin public immutable stablecoin;
+
+    /// @notice Minimum delay (in seconds) accepted at construction. Constructor
+    /// sanity guard against gross operator misconfiguration.
+    uint256 public constant MIN_DELAY_FLOOR = 1 days;
+
+    /// @notice The minDelay passed at construction. Acts as a permanent floor
+    /// on `updateDelay`: governance can raise the delay, but cannot lower it
+    /// below this deploy-time value. Closes the path where a proposer schedules
+    /// `updateDelay(0)` to undermine the timelock.
+    uint256 public immutable deploymentMinDelay;
+
+    error ZeroStablecoin();
+    error DelayBelowFloor();
+    error DelayBelowDeployedFloor();
+    error NoProposers();
+
+    constructor(
+        Stablecoin stablecoin_,
+        uint256 minDelay,
+        address[] memory proposers,
+        address[] memory executors,
+        address admin
+    ) TimelockController(minDelay, proposers, executors, admin) {
+        if (address(stablecoin_) == address(0)) revert ZeroStablecoin();
+        if (minDelay < MIN_DELAY_FLOOR) revert DelayBelowFloor();
+        if (proposers.length == 0) revert NoProposers();
+        stablecoin = stablecoin_;
+        deploymentMinDelay = minDelay;
+    }
+
+    /// @notice Overrides `TimelockController.updateDelay` to refuse any new
+    /// delay below the deploy-time `deploymentMinDelay`. Reachable only via a
+    /// matured timelock operation targeting `address(this)`, same as OZ.
+    function updateDelay(uint256 newDelay) public virtual override {
+        if (newDelay < deploymentMinDelay) revert DelayBelowDeployedFloor();
+        super.updateDelay(newDelay);
+    }
+
+    /// @notice Schedules `grantRole(ADMIN_ROLE, newAdmin)` on the bound stablecoin.
+    function scheduleGrantAdmin(address newAdmin, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.grantRole, (stablecoin.ADMIN_ROLE(), newAdmin));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `revokeRole(ADMIN_ROLE, oldAdmin)` on the bound stablecoin.
+    function scheduleRevokeAdmin(address oldAdmin, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.revokeRole, (stablecoin.ADMIN_ROLE(), oldAdmin));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `addMinter(minter, cap)` on the bound stablecoin.
+    function scheduleAddMinter(address minter, uint256 cap, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.addMinter, (minter, cap));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `removeMinter(minter)` on the bound stablecoin.
+    function scheduleRemoveMinter(address minter, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.removeMinter, (minter));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules `modifyMinterAllowance(minter, newCap)` on the bound stablecoin.
+    function scheduleModifyMinterAllowance(address minter, uint256 newCap, bytes32 salt, uint256 delay) external {
+        bytes memory data = abi.encodeCall(stablecoin.modifyMinterAllowance, (minter, newCap));
+        _scheduleStablecoinCall(data, salt, delay);
+    }
+
+    /// @notice Schedules a UUPS `upgradeToAndCall(newImplementation, data)` on the
+    /// bound stablecoin proxy. Use empty `data` for a pure implementation swap;
+    /// pass ABI-encoded reinitializer calldata for staged migrations.
+    function scheduleUpgrade(address newImplementation, bytes calldata data, bytes32 salt, uint256 delay) external {
+        bytes memory payload = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImplementation, data));
+        _scheduleStablecoinCall(payload, salt, delay);
+    }
+
+    function _scheduleStablecoinCall(bytes memory data, bytes32 salt, uint256 delay) private {
+        Address.functionDelegateCall(
+            address(this), abi.encodeCall(this.schedule, (address(stablecoin), 0, data, bytes32(0), salt, delay))
+        );
+    }
+}

--- a/src/StablecoinTimelock.sol
+++ b/src/StablecoinTimelock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
 import {Stablecoin} from "./Stablecoin.sol";

--- a/src/StablecoinTimelock.sol
+++ b/src/StablecoinTimelock.sol
@@ -34,6 +34,15 @@ contract StablecoinTimelock is TimelockController {
     error ZeroStablecoin();
     error DelayBelowDeployedFloor();
     error NoProposers();
+    /// @dev `scheduleUpgrade` was called with an implementation address that has
+    /// no bytecode. Surfaces at schedule time so the proposer doesn't burn the
+    /// `minDelay` window before discovering the typo at execute time.
+    error NotAContract(address impl);
+    /// @dev `scheduleRevokeAdmin` was called with an address that does not hold
+    /// `ADMIN_ROLE` on the bound stablecoin. Without this check OZ's
+    /// `_revokeRole` would silently return `false` at execute time after the
+    /// `minDelay` window had already elapsed.
+    error NotAnAdmin(address account);
 
     constructor(
         Stablecoin stablecoin_,
@@ -63,7 +72,13 @@ contract StablecoinTimelock is TimelockController {
     }
 
     /// @notice Schedules `revokeRole(ADMIN_ROLE, oldAdmin)` on the bound stablecoin.
+    /// @dev Rejects `oldAdmin` values that do not currently hold `ADMIN_ROLE`.
+    /// Without this guard a typo'd address would queue a call that OZ's
+    /// `_revokeRole` silently no-ops on at execute time, wasting the `minDelay`
+    /// window. Asymmetric with `removeMinter`, which already requires positive
+    /// existence; this brings the admin path in line.
     function scheduleRevokeAdmin(address oldAdmin, bytes32 salt, uint256 delay) external {
+        if (!stablecoin.hasRole(stablecoin.ADMIN_ROLE(), oldAdmin)) revert NotAnAdmin(oldAdmin);
         bytes memory data = abi.encodeCall(stablecoin.revokeRole, (stablecoin.ADMIN_ROLE(), oldAdmin));
         _scheduleStablecoinCall(data, salt, delay);
     }
@@ -89,7 +104,11 @@ contract StablecoinTimelock is TimelockController {
     /// @notice Schedules a UUPS `upgradeToAndCall(newImplementation, data)` on the
     /// bound stablecoin proxy. Use empty `data` for a pure implementation swap;
     /// pass ABI-encoded reinitializer calldata for staged migrations.
+    /// @dev Rejects `newImplementation` values with no bytecode (EOAs,
+    /// `address(0)`, never-deployed addresses). Without this guard a fat-finger
+    /// would only surface at execute time, wasting the `minDelay` window.
     function scheduleUpgrade(address newImplementation, bytes calldata data, bytes32 salt, uint256 delay) external {
+        if (newImplementation.code.length == 0) revert NotAContract(newImplementation);
         bytes memory payload = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImplementation, data));
         _scheduleStablecoinCall(payload, salt, delay);
     }

--- a/src/StablecoinTimelock.sol
+++ b/src/StablecoinTimelock.sol
@@ -24,18 +24,14 @@ contract StablecoinTimelock is TimelockController {
     /// and not changeable thereafter.
     Stablecoin public immutable stablecoin;
 
-    /// @notice Minimum delay (in seconds) accepted at construction. Constructor
-    /// sanity guard against gross operator misconfiguration.
-    uint256 public constant MIN_DELAY_FLOOR = 1 days;
-
-    /// @notice The minDelay passed at construction. Acts as a permanent floor
+    /// @notice The `minDelay` passed at construction. Acts as a permanent floor
     /// on `updateDelay`: governance can raise the delay, but cannot lower it
     /// below this deploy-time value. Closes the path where a proposer schedules
-    /// `updateDelay(0)` to undermine the timelock.
+    /// `updateDelay(0)` to undermine the timelock. Operators set the floor they
+    /// want at deploy time — no hardcoded minimum is imposed by this contract.
     uint256 public immutable deploymentMinDelay;
 
     error ZeroStablecoin();
-    error DelayBelowFloor();
     error DelayBelowDeployedFloor();
     error NoProposers();
 
@@ -47,7 +43,6 @@ contract StablecoinTimelock is TimelockController {
         address admin
     ) TimelockController(minDelay, proposers, executors, admin) {
         if (address(stablecoin_) == address(0)) revert ZeroStablecoin();
-        if (minDelay < MIN_DELAY_FLOOR) revert DelayBelowFloor();
         if (proposers.length == 0) revert NoProposers();
         stablecoin = stablecoin_;
         deploymentMinDelay = minDelay;

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -550,6 +550,33 @@ contract StablecoinTest is Test {
         assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
     }
 
+    /// @dev Direct (non-timelock) revoke of ADMIN_ROLE on a non-holder must
+    /// revert with `NotAnAdmin`. Closes OZ's silent-no-op path at the source,
+    /// independent of any timelock helper.
+    function test_RevokeAdminOnNonHolderReverts() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address nonHolder = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(adminRole, nonHolder));
+
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.NotAnAdmin.selector, nonHolder));
+        stablecoin.revokeRole(adminRole, nonHolder);
+    }
+
+    /// @dev A non-admin self-renouncing ADMIN_ROLE previously silently no-op'd
+    /// (OZ's `_revokeRole` returned `false`). With the new guard it reverts
+    /// with `NotAnAdmin`. Exercises the `_revokeRole` path reached via
+    /// `renounceRole` rather than `revokeRole`.
+    function test_RenounceAdminByNonAdminReverts() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address nonAdmin = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(adminRole, nonAdmin));
+
+        vm.prank(nonAdmin);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.NotAnAdmin.selector, nonAdmin));
+        stablecoin.renounceRole(adminRole, nonAdmin);
+    }
+
     function test_NonAdminCannotGrantAdminRole() public {
         bytes32 adminRole = stablecoin.ADMIN_ROLE();
         address nonAdmin = address(0xBADD);

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -518,7 +518,7 @@ contract StablecoinTest is Test {
 
         // Only the original ADMIN holds ADMIN_ROLE; revoking it would leave zero admins.
         vm.prank(ADMIN);
-        vm.expectRevert(Stablecoin.LastAdminCannotBeRemoved.selector);
+        vm.expectRevert(Stablecoin.AdminRoleCannotBeEmpty.selector);
         stablecoin.revokeRole(adminRole, ADMIN);
 
         assertTrue(stablecoin.hasRole(adminRole, ADMIN));
@@ -528,7 +528,7 @@ contract StablecoinTest is Test {
         bytes32 adminRole = stablecoin.ADMIN_ROLE();
 
         vm.prank(ADMIN);
-        vm.expectRevert(Stablecoin.LastAdminCannotBeRemoved.selector);
+        vm.expectRevert(Stablecoin.AdminRoleCannotBeEmpty.selector);
         stablecoin.renounceRole(adminRole, ADMIN);
 
         assertTrue(stablecoin.hasRole(adminRole, ADMIN));

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -6,6 +6,7 @@ import {Stablecoin} from "../src/Stablecoin.sol";
 import {
     ERC1967Proxy
 } from "lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 
 contract StablecoinTest is Test {
     Stablecoin public stablecoin;
@@ -480,6 +481,146 @@ contract StablecoinTest is Test {
         emit Stablecoin.AccountUnfrozen(account);
         stablecoin.unfreeze(account);
         assertFalse(stablecoin.frozen(account));
+    }
+
+    // ============ ADMIN_ROLE Rotation Tests (M-01) ============
+
+    function test_AdminCanGrantAdminRole() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address newAdmin = address(0xAD1);
+
+        vm.prank(ADMIN);
+        stablecoin.grantRole(adminRole, newAdmin);
+
+        assertTrue(stablecoin.hasRole(adminRole, newAdmin));
+        assertTrue(stablecoin.hasRole(adminRole, ADMIN));
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 2);
+    }
+
+    function test_AdminCanRevokeOtherAdmin() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address otherAdmin = address(0xAD1);
+
+        vm.startPrank(ADMIN);
+        stablecoin.grantRole(adminRole, otherAdmin);
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 2);
+
+        stablecoin.revokeRole(adminRole, otherAdmin);
+        vm.stopPrank();
+
+        assertFalse(stablecoin.hasRole(adminRole, otherAdmin));
+        assertTrue(stablecoin.hasRole(adminRole, ADMIN));
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
+    }
+
+    function test_CannotRevokeLastAdmin() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+
+        // Only the original ADMIN holds ADMIN_ROLE; revoking it would leave zero admins.
+        vm.prank(ADMIN);
+        vm.expectRevert(Stablecoin.LastAdminCannotBeRemoved.selector);
+        stablecoin.revokeRole(adminRole, ADMIN);
+
+        assertTrue(stablecoin.hasRole(adminRole, ADMIN));
+    }
+
+    function test_CannotRenounceLastAdmin() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+
+        vm.prank(ADMIN);
+        vm.expectRevert(Stablecoin.LastAdminCannotBeRemoved.selector);
+        stablecoin.renounceRole(adminRole, ADMIN);
+
+        assertTrue(stablecoin.hasRole(adminRole, ADMIN));
+    }
+
+    function test_CanRenounceAdminWhenMultipleAdminsExist() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address otherAdmin = address(0xAD1);
+
+        vm.startPrank(ADMIN);
+        stablecoin.grantRole(adminRole, otherAdmin);
+        // The original ADMIN can now safely renounce because otherAdmin remains.
+        stablecoin.renounceRole(adminRole, ADMIN);
+        vm.stopPrank();
+
+        assertFalse(stablecoin.hasRole(adminRole, ADMIN));
+        assertTrue(stablecoin.hasRole(adminRole, otherAdmin));
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
+    }
+
+    function test_NonAdminCannotGrantAdminRole() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address nonAdmin = address(0xBADD);
+        bytes memory expectedError =
+            abi.encodeWithSignature("AccessControlUnauthorizedAccount(address,bytes32)", nonAdmin, adminRole);
+
+        vm.prank(nonAdmin);
+        vm.expectRevert(expectedError);
+        stablecoin.grantRole(adminRole, address(0xAD1));
+    }
+
+    function test_AdminRotationFullCycle() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address newAdmin = address(0xAD1);
+
+        // 1. New admin is granted; 2. Old admin renounces.
+        vm.startPrank(ADMIN);
+        stablecoin.grantRole(adminRole, newAdmin);
+        stablecoin.renounceRole(adminRole, ADMIN);
+        vm.stopPrank();
+
+        // 3. The new admin can now exercise admin operations.
+        address newMinter = address(0xBEEF);
+        vm.prank(newAdmin);
+        stablecoin.addMinter(newMinter, 100);
+        assertTrue(stablecoin.hasRole(stablecoin.MINTER_ROLE(), newMinter));
+
+        // 4. The old admin can no longer.
+        bytes memory expectedError =
+            abi.encodeWithSignature("AccessControlUnauthorizedAccount(address,bytes32)", ADMIN, adminRole);
+        vm.prank(ADMIN);
+        vm.expectRevert(expectedError);
+        stablecoin.addMinter(address(0xCAFE), 100);
+    }
+
+    function test_TimelockControllerAsAdmin() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+
+        // Deploy a TimelockController with the ADMIN address as the sole proposer
+        // and open execution (anyone can execute matured operations).
+        uint256 delay = 1 days;
+        address[] memory proposers = new address[](1);
+        proposers[0] = ADMIN;
+        address[] memory executors = new address[](1);
+        executors[0] = address(0); // open execution
+        TimelockController timelock = new TimelockController(delay, proposers, executors, address(0));
+
+        // Hand ADMIN_ROLE over to the timelock and remove the EOA admin.
+        vm.startPrank(ADMIN);
+        stablecoin.grantRole(adminRole, address(timelock));
+        stablecoin.renounceRole(adminRole, ADMIN);
+        vm.stopPrank();
+
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
+        assertTrue(stablecoin.hasRole(adminRole, address(timelock)));
+
+        // From now on, any admin action requires going through the timelock.
+        address newMinter = address(0xBEEF);
+        bytes memory callData = abi.encodeCall(stablecoin.addMinter, (newMinter, 1000));
+        bytes32 salt = bytes32(uint256(1));
+
+        vm.prank(ADMIN);
+        timelock.schedule(address(stablecoin), 0, callData, bytes32(0), salt, delay);
+
+        // Before the delay matures, execution reverts.
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, callData, bytes32(0), salt);
+
+        // After the delay, execution succeeds and the minter is added.
+        vm.warp(block.timestamp + delay + 1);
+        timelock.execute(address(stablecoin), 0, callData, bytes32(0), salt);
+        assertTrue(stablecoin.hasRole(stablecoin.MINTER_ROLE(), newMinter));
     }
 
     function test_NonAdminCannotUpgrade() public {

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -7,6 +7,7 @@ import {
     ERC1967Proxy
 } from "lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {OldStablecoin} from "../script/integration/OldStablecoin.sol";
 
 contract StablecoinTest is Test {
     Stablecoin public stablecoin;
@@ -621,6 +622,92 @@ contract StablecoinTest is Test {
         vm.warp(block.timestamp + delay + 1);
         timelock.execute(address(stablecoin), 0, callData, bytes32(0), salt);
         assertTrue(stablecoin.hasRole(stablecoin.MINTER_ROLE(), newMinter));
+    }
+
+    // ============ reinitializeAdminRole Tests ============
+
+    function test_ReinitializeAdminRole_RevertsOnFreshDeploy() public {
+        // A freshly-deployed proxy is already at version 1 with the role admin
+        // correctly set; calling reinitializer(2) here would normally succeed
+        // and set _initialized to 2. We assert this happens once, then a
+        // second call reverts.
+        vm.prank(ADMIN);
+        stablecoin.reinitializeAdminRole();
+        assertEq(stablecoin.getRoleAdmin(stablecoin.ADMIN_ROLE()), stablecoin.ADMIN_ROLE());
+
+        // Second call reverts with InvalidInitialization (version cap reached).
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        stablecoin.reinitializeAdminRole();
+    }
+
+    function test_ReinitializeAdminRole_OnlyAdmin() public {
+        address nonAdmin = address(0xBADD);
+        bytes memory expectedError = abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)", nonAdmin, stablecoin.ADMIN_ROLE()
+        );
+
+        vm.prank(nonAdmin);
+        vm.expectRevert(expectedError);
+        stablecoin.reinitializeAdminRole();
+    }
+
+    /// @dev End-to-end coverage of the upgrade-from-main migration. Deploys the
+    /// pre-M-01 implementation behind a proxy, proves the bug exists (the
+    /// initial admin can't rotate ADMIN_ROLE), then atomically upgrades to
+    /// this branch's implementation via `upgradeToAndCall(newImpl,
+    /// reinitializeAdminRole())`. After the upgrade the role admin slot is
+    /// repaired and the admin can rotate the role to a fresh address.
+    /// Runs under standard `forge test` — no anvil required, complementing the
+    /// bash-orchestrated integration script.
+    function test_UpgradeFromMain_RepairsRoleAdminAndAllowsRotation() public {
+        // 1. Deploy OldStablecoin behind a proxy. Use a distinct admin EOA so
+        //    it's clear we're not relying on test-class state.
+        address oldAdmin = address(0xA1);
+        OldStablecoin oldImpl = new OldStablecoin();
+        ERC1967Proxy oldProxy = new ERC1967Proxy(
+            address(oldImpl),
+            abi.encodeCall(OldStablecoin.initialize, ("Legacy", "LGC", 18, oldAdmin, oldAdmin, oldAdmin, oldAdmin))
+        );
+        OldStablecoin legacy = OldStablecoin(address(oldProxy));
+        bytes32 adminRole = legacy.ADMIN_ROLE();
+
+        // 2. Prove the bug: on the pre-M-01 implementation the role admin of
+        //    ADMIN_ROLE is DEFAULT_ADMIN_ROLE, held by no one. So even the
+        //    legitimate admin can't grant ADMIN_ROLE to anyone. This is the
+        //    failure mode the audit flagged (M-01).
+        address newHolder = address(0xA2);
+        vm.prank(oldAdmin);
+        vm.expectRevert(
+            abi.encodeWithSignature("AccessControlUnauthorizedAccount(address,bytes32)", oldAdmin, bytes32(0))
+        );
+        legacy.grantRole(adminRole, newHolder);
+
+        // 3. Atomic upgrade + reinit. The reinit fixes the role admin slot in
+        //    the same tx the implementation flips, eliminating any window in
+        //    which the proxy is on new code with an unrepaired storage layout.
+        Stablecoin newImpl = new Stablecoin();
+        vm.prank(oldAdmin);
+        Stablecoin(address(oldProxy))
+            .upgradeToAndCall(address(newImpl), abi.encodeCall(Stablecoin.reinitializeAdminRole, ()));
+        Stablecoin upgraded = Stablecoin(address(oldProxy));
+
+        // 4. Slot is now repaired: ADMIN_ROLE administers itself.
+        assertEq(upgraded.getRoleAdmin(adminRole), adminRole, "role admin slot not repaired");
+
+        // 5. Old admin can now do the thing that was previously impossible:
+        //    grant ADMIN_ROLE to a fresh holder.
+        vm.prank(oldAdmin);
+        upgraded.grantRole(adminRole, newHolder);
+        assertTrue(upgraded.hasRole(adminRole, newHolder), "grantRole failed post-upgrade");
+        assertTrue(upgraded.hasRole(adminRole, oldAdmin), "oldAdmin lost the role");
+        assertEq(upgraded.getRoleMemberCount(adminRole), 2);
+
+        // 6. The reinitializer's version cap is consumed: a second call must
+        //    revert, so we can't accidentally repair twice.
+        vm.prank(oldAdmin);
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        upgraded.reinitializeAdminRole();
     }
 
     function test_NonAdminCannotUpgrade() public {

--- a/test/StablecoinTimelock.t.sol
+++ b/test/StablecoinTimelock.t.sol
@@ -91,6 +91,30 @@ contract StablecoinTimelockTest is Test {
         return abi.encodeCall(stablecoin.revokeRole, (stablecoin.ADMIN_ROLE(), oldAdmin));
     }
 
+    function _grantBurnerCalldata(address account) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.grantRole, (stablecoin.BURNER_ROLE(), account));
+    }
+
+    function _revokeBurnerCalldata(address account) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.revokeRole, (stablecoin.BURNER_ROLE(), account));
+    }
+
+    function _grantPauserCalldata(address account) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.grantRole, (stablecoin.PAUSER_ROLE(), account));
+    }
+
+    function _revokePauserCalldata(address account) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.revokeRole, (stablecoin.PAUSER_ROLE(), account));
+    }
+
+    function _grantFreezerCalldata(address account) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.grantRole, (stablecoin.FREEZER_ROLE(), account));
+    }
+
+    function _revokeFreezerCalldata(address account) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.revokeRole, (stablecoin.FREEZER_ROLE(), account));
+    }
+
     function _addMinterCalldata(address minter, uint256 cap) internal view returns (bytes memory) {
         return abi.encodeCall(stablecoin.addMinter, (minter, cap));
     }
@@ -187,6 +211,181 @@ contract StablecoinTimelockTest is Test {
 
         assertFalse(stablecoin.hasRole(adminRole, otherAdmin));
         assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
+    }
+
+    // ============ scheduleGrantBurner / scheduleRevokeBurner ============
+
+    function test_E2E_GrantBurner() public {
+        bytes32 burnerRole = stablecoin.BURNER_ROLE();
+        address newBurner = address(0xB1);
+        assertFalse(stablecoin.hasRole(burnerRole, newBurner), "precondition: must not be burner");
+
+        bytes32 salt = bytes32(uint256(40));
+        bytes memory data = _grantBurnerCalldata(newBurner);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantBurner(newBurner, salt, DELAY);
+
+        // Cannot execute before the delay elapses.
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertTrue(stablecoin.hasRole(burnerRole, newBurner));
+    }
+
+    function test_E2E_RevokeBurner() public {
+        bytes32 burnerRole = stablecoin.BURNER_ROLE();
+        // ADMIN holds BURNER_ROLE from setUp: initialize granted all four roles to ADMIN,
+        // and setUp only renounced ADMIN_ROLE. Unlike ADMIN_ROLE, BURNER_ROLE has no
+        // last-holder guard, so revoking the sole holder is allowed.
+        assertTrue(stablecoin.hasRole(burnerRole, ADMIN), "precondition: ADMIN holds BURNER_ROLE");
+
+        bytes32 salt = bytes32(uint256(41));
+        bytes memory data = _revokeBurnerCalldata(ADMIN);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokeBurner(ADMIN, salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertFalse(stablecoin.hasRole(burnerRole, ADMIN));
+    }
+
+    /// @notice Scheduling a revoke against an address that does not hold BURNER_ROLE
+    /// must revert at schedule time so the proposer does not burn a full minDelay
+    /// window only to have OZ's `_revokeRole` silently no-op at execute time.
+    function test_ScheduleRevokeBurnerRevertsOnNonHolder() public {
+        address typo = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(stablecoin.BURNER_ROLE(), typo), "precondition: must not be burner");
+        bytes32 salt = bytes32(uint256(42));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotABurner.selector, typo));
+        timelock.scheduleRevokeBurner(typo, salt, DELAY);
+    }
+
+    function test_ScheduleRevokeBurnerRevertsOnZeroAddress() public {
+        bytes32 salt = bytes32(uint256(43));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotABurner.selector, address(0)));
+        timelock.scheduleRevokeBurner(address(0), salt, DELAY);
+    }
+
+    // ============ scheduleGrantPauser / scheduleRevokePauser ============
+
+    function test_E2E_GrantPauser() public {
+        bytes32 pauserRole = stablecoin.PAUSER_ROLE();
+        address newPauser = address(0xB2);
+        assertFalse(stablecoin.hasRole(pauserRole, newPauser), "precondition: must not be pauser");
+
+        bytes32 salt = bytes32(uint256(44));
+        bytes memory data = _grantPauserCalldata(newPauser);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantPauser(newPauser, salt, DELAY);
+
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertTrue(stablecoin.hasRole(pauserRole, newPauser));
+    }
+
+    function test_E2E_RevokePauser() public {
+        bytes32 pauserRole = stablecoin.PAUSER_ROLE();
+        assertTrue(stablecoin.hasRole(pauserRole, ADMIN), "precondition: ADMIN holds PAUSER_ROLE");
+
+        bytes32 salt = bytes32(uint256(45));
+        bytes memory data = _revokePauserCalldata(ADMIN);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokePauser(ADMIN, salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertFalse(stablecoin.hasRole(pauserRole, ADMIN));
+    }
+
+    function test_ScheduleRevokePauserRevertsOnNonHolder() public {
+        address typo = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(stablecoin.PAUSER_ROLE(), typo), "precondition: must not be pauser");
+        bytes32 salt = bytes32(uint256(46));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAPauser.selector, typo));
+        timelock.scheduleRevokePauser(typo, salt, DELAY);
+    }
+
+    function test_ScheduleRevokePauserRevertsOnZeroAddress() public {
+        bytes32 salt = bytes32(uint256(47));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAPauser.selector, address(0)));
+        timelock.scheduleRevokePauser(address(0), salt, DELAY);
+    }
+
+    // ============ scheduleGrantFreezer / scheduleRevokeFreezer ============
+
+    function test_E2E_GrantFreezer() public {
+        bytes32 freezerRole = stablecoin.FREEZER_ROLE();
+        address newFreezer = address(0xB3);
+        assertFalse(stablecoin.hasRole(freezerRole, newFreezer), "precondition: must not be freezer");
+
+        bytes32 salt = bytes32(uint256(48));
+        bytes memory data = _grantFreezerCalldata(newFreezer);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantFreezer(newFreezer, salt, DELAY);
+
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertTrue(stablecoin.hasRole(freezerRole, newFreezer));
+    }
+
+    function test_E2E_RevokeFreezer() public {
+        bytes32 freezerRole = stablecoin.FREEZER_ROLE();
+        assertTrue(stablecoin.hasRole(freezerRole, ADMIN), "precondition: ADMIN holds FREEZER_ROLE");
+
+        bytes32 salt = bytes32(uint256(49));
+        bytes memory data = _revokeFreezerCalldata(ADMIN);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokeFreezer(ADMIN, salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertFalse(stablecoin.hasRole(freezerRole, ADMIN));
+    }
+
+    function test_ScheduleRevokeFreezerRevertsOnNonHolder() public {
+        address typo = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(stablecoin.FREEZER_ROLE(), typo), "precondition: must not be freezer");
+        bytes32 salt = bytes32(uint256(50));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAFreezer.selector, typo));
+        timelock.scheduleRevokeFreezer(typo, salt, DELAY);
+    }
+
+    function test_ScheduleRevokeFreezerRevertsOnZeroAddress() public {
+        bytes32 salt = bytes32(uint256(51));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAFreezer.selector, address(0)));
+        timelock.scheduleRevokeFreezer(address(0), salt, DELAY);
     }
 
     // ============ scheduleAddMinter ============

--- a/test/StablecoinTimelock.t.sol
+++ b/test/StablecoinTimelock.t.sol
@@ -393,6 +393,105 @@ contract StablecoinTimelockTest is Test {
         assertEq(timelock.deploymentMinDelay(), DELAY);
     }
 
+    // ============ updateDelay self-call guard (boundary + direct call) ============
+
+    function test_DirectUpdateDelayReverts() public {
+        address caller = address(0xDEAD);
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSignature("TimelockUnauthorizedCaller(address)", caller));
+        timelock.updateDelay(DELAY);
+    }
+
+    function test_UpdateDelayExactlyAtFloorSucceeds() public {
+        // Raise the delay first so there is room to lower it back to the floor.
+        uint256 raised = 7 days;
+        bytes memory raiseData = abi.encodeCall(timelock.updateDelay, (raised));
+        bytes32 raiseSalt = bytes32(uint256(22));
+        vm.prank(PROPOSER);
+        timelock.schedule(address(timelock), 0, raiseData, bytes32(0), raiseSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(timelock), 0, raiseData, bytes32(0), raiseSalt);
+        assertEq(timelock.getMinDelay(), raised);
+
+        // Lower to exactly the deployment floor — boundary case, override uses `<`.
+        bytes memory lowerData = abi.encodeCall(timelock.updateDelay, (DELAY));
+        bytes32 lowerSalt = bytes32(uint256(23));
+        vm.prank(PROPOSER);
+        timelock.schedule(address(timelock), 0, lowerData, bytes32(0), lowerSalt, raised);
+        vm.warp(block.timestamp + raised + 1);
+        timelock.execute(address(timelock), 0, lowerData, bytes32(0), lowerSalt);
+
+        assertEq(timelock.getMinDelay(), DELAY);
+        assertEq(timelock.deploymentMinDelay(), DELAY);
+    }
+
+    // ============ last-admin guard fires when reached through the timelock ============
+
+    function test_E2E_RevokeLastAdminRevertsThroughTimelock() public {
+        // Timelock is the only admin (per setUp). Scheduling revokeAdmin(timelock) is fine —
+        // the timelock just queues calldata. Execution must revert with the stablecoin's
+        // LastAdminCannotBeRemoved guard.
+        bytes32 salt = bytes32(uint256(24));
+        bytes memory data = _revokeAdminCalldata(address(timelock));
+
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokeAdmin(address(timelock), salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertTrue(stablecoin.hasRole(stablecoin.ADMIN_ROLE(), address(timelock)));
+        assertEq(stablecoin.getRoleMemberCount(stablecoin.ADMIN_ROLE()), 1);
+    }
+
+    // ============ scheduleUpgrade forwards reinitializer data verbatim ============
+
+    function test_ScheduleUpgradeWithReinitializerDataCalldataMatchesManual() public {
+        address newImpl = address(0xCAFEBABE);
+        bytes memory reinitCall = abi.encodeWithSignature("reinitialize(uint8)", uint8(2));
+        bytes32 salt = bytes32(uint256(25));
+
+        bytes memory expected = _upgradeCalldata(newImpl, reinitCall);
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleUpgrade(newImpl, reinitCall, salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    // ============ paused stablecoin: removeMinter path ============
+
+    function test_E2E_RemoveMinterRevertsWhenStablecoinPaused() public {
+        address minter = address(0xBEEF);
+
+        // Add the minter first while unpaused.
+        bytes32 addSalt = bytes32(uint256(26));
+        bytes memory addData = _addMinterCalldata(minter, 1000);
+        vm.prank(PROPOSER);
+        timelock.scheduleAddMinter(minter, 1000, addSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, addData, bytes32(0), addSalt);
+        assertTrue(stablecoin.hasRole(stablecoin.MINTER_ROLE(), minter));
+
+        // Pause, schedule remove, then attempt execution.
+        vm.prank(ADMIN);
+        stablecoin.pause();
+
+        bytes32 removeSalt = bytes32(uint256(27));
+        bytes memory removeData = _removeMinterCalldata(minter);
+        vm.prank(PROPOSER);
+        timelock.scheduleRemoveMinter(minter, removeSalt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, removeData, bytes32(0), removeSalt);
+
+        // Minter is still present because removal reverted.
+        assertTrue(stablecoin.hasRole(stablecoin.MINTER_ROLE(), minter));
+    }
+
     // ============ access control ============
 
     function test_NonProposerCannotCallHelpers() public {

--- a/test/StablecoinTimelock.t.sol
+++ b/test/StablecoinTimelock.t.sol
@@ -144,12 +144,22 @@ contract StablecoinTimelockTest is Test {
     // ============ scheduleRevokeAdmin ============
 
     function test_RevokeAdminCalldataMatchesManual() public {
+        // Grant a second admin first — scheduleRevokeAdmin now requires a positive role
+        // check at schedule time, so the target must actually hold ADMIN_ROLE (see C1).
+        address otherAdmin = address(0xAD1);
+        bytes32 grantSalt = bytes32(uint256(100));
+        bytes memory grantData = _adminCalldata(otherAdmin);
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantAdmin(otherAdmin, grantSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, grantData, bytes32(0), grantSalt);
+
         bytes32 salt = bytes32(uint256(3));
-        bytes memory expected = _revokeAdminCalldata(address(0xAD1));
+        bytes memory expected = _revokeAdminCalldata(otherAdmin);
         bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
 
         vm.prank(PROPOSER);
-        timelock.scheduleRevokeAdmin(address(0xAD1), salt, DELAY);
+        timelock.scheduleRevokeAdmin(otherAdmin, salt, DELAY);
 
         assertTrue(timelock.isOperation(manualId));
     }
@@ -283,7 +293,8 @@ contract StablecoinTimelockTest is Test {
     // ============ scheduleUpgrade ============
 
     function test_UpgradeCalldataMatchesManual() public {
-        address newImpl = address(0xCAFEBABE);
+        // Use a real deployed contract — scheduleUpgrade rejects non-contracts at schedule time (see I1).
+        address newImpl = address(new Stablecoin());
         bytes32 salt = bytes32(uint256(14));
         bytes memory expected = _upgradeCalldata(newImpl, "");
         bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
@@ -433,7 +444,9 @@ contract StablecoinTimelockTest is Test {
     function test_E2E_RevokeLastAdminRevertsThroughTimelock() public {
         // Timelock is the only admin (per setUp). Scheduling revokeAdmin(timelock) is fine —
         // the timelock just queues calldata. Execution must revert with the stablecoin's
-        // AdminRoleCannotBeEmpty guard.
+        // AdminRoleCannotBeEmpty guard. OZ's TimelockController bubbles the raw inner
+        // revert via Address.verifyCallResult, so the selector match catches the
+        // exact error path and would notice a regression that swapped the cause.
         bytes32 salt = bytes32(uint256(24));
         bytes memory data = _revokeAdminCalldata(address(timelock));
 
@@ -441,7 +454,7 @@ contract StablecoinTimelockTest is Test {
         timelock.scheduleRevokeAdmin(address(timelock), salt, DELAY);
 
         vm.warp(block.timestamp + DELAY + 1);
-        vm.expectRevert();
+        vm.expectRevert(Stablecoin.AdminRoleCannotBeEmpty.selector);
         timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
 
         assertTrue(stablecoin.hasRole(stablecoin.ADMIN_ROLE(), address(timelock)));
@@ -451,7 +464,8 @@ contract StablecoinTimelockTest is Test {
     // ============ scheduleUpgrade forwards reinitializer data verbatim ============
 
     function test_ScheduleUpgradeWithReinitializerDataCalldataMatchesManual() public {
-        address newImpl = address(0xCAFEBABE);
+        // Use a real deployed contract — scheduleUpgrade rejects non-contracts at schedule time (see I1).
+        address newImpl = address(new Stablecoin());
         bytes memory reinitCall = abi.encodeWithSignature("reinitialize(uint8)", uint8(2));
         bytes32 salt = bytes32(uint256(25));
 
@@ -508,5 +522,123 @@ contract StablecoinTimelockTest is Test {
         vm.prank(nonProposer);
         vm.expectRevert(expectedError);
         timelock.scheduleGrantAdmin(address(0xAD1), salt, DELAY);
+    }
+
+    // ============ scheduleUpgrade input validation (I1) ============
+
+    /// @notice Scheduling an upgrade to an EOA / unallocated address must revert
+    /// at schedule time so the proposer doesn't burn a full minDelay window
+    /// before discovering the implementation has no code.
+    function test_ScheduleUpgradeRevertsOnNonContractImplementation() public {
+        address nonContract = address(0xCAFEBABE);
+        assertEq(nonContract.code.length, 0, "precondition: address must have no code");
+        bytes32 salt = bytes32(uint256(28));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAContract.selector, nonContract));
+        timelock.scheduleUpgrade(nonContract, "", salt, DELAY);
+    }
+
+    function test_ScheduleUpgradeRevertsOnZeroAddressImplementation() public {
+        bytes32 salt = bytes32(uint256(29));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAContract.selector, address(0)));
+        timelock.scheduleUpgrade(address(0), "", salt, DELAY);
+    }
+
+    function test_ScheduleUpgradeAcceptsRealContract() public {
+        Stablecoin newImpl = new Stablecoin();
+        bytes32 salt = bytes32(uint256(30));
+
+        vm.prank(PROPOSER);
+        timelock.scheduleUpgrade(address(newImpl), "", salt, DELAY);
+
+        bytes memory data = _upgradeCalldata(address(newImpl), "");
+        bytes32 opId = timelock.hashOperation(address(stablecoin), 0, data, bytes32(0), salt);
+        assertTrue(timelock.isOperation(opId));
+    }
+
+    // ============ scheduleRevokeAdmin input validation (C1) ============
+
+    /// @notice Scheduling a revoke against an address that doesn't hold ADMIN_ROLE
+    /// must revert at schedule time. Otherwise the operator burns a full minDelay
+    /// window only to discover the revoke silently no-ops at execute time.
+    function test_ScheduleRevokeAdminRevertsOnNonAdmin() public {
+        address typo = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(stablecoin.ADMIN_ROLE(), typo), "precondition: must not be admin");
+        bytes32 salt = bytes32(uint256(31));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAnAdmin.selector, typo));
+        timelock.scheduleRevokeAdmin(typo, salt, DELAY);
+    }
+
+    function test_ScheduleRevokeAdminRevertsOnZeroAddress() public {
+        bytes32 salt = bytes32(uint256(32));
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(StablecoinTimelock.NotAnAdmin.selector, address(0)));
+        timelock.scheduleRevokeAdmin(address(0), salt, DELAY);
+    }
+
+    function test_ScheduleRevokeAdminAcceptsExistingAdmin() public {
+        // First grant a second admin so revoking is allowed by the last-admin guard.
+        address otherAdmin = address(0xAD1);
+        bytes32 grantSalt = bytes32(uint256(33));
+        bytes memory grantData = _adminCalldata(otherAdmin);
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantAdmin(otherAdmin, grantSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, grantData, bytes32(0), grantSalt);
+        assertTrue(stablecoin.hasRole(stablecoin.ADMIN_ROLE(), otherAdmin));
+
+        // Now scheduling a revoke against the real admin must succeed at schedule time.
+        bytes32 revokeSalt = bytes32(uint256(34));
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokeAdmin(otherAdmin, revokeSalt, DELAY);
+
+        bytes memory revokeData = _revokeAdminCalldata(otherAdmin);
+        bytes32 opId = timelock.hashOperation(address(stablecoin), 0, revokeData, bytes32(0), revokeSalt);
+        assertTrue(timelock.isOperation(opId));
+    }
+
+    // ============ raw schedule() bypass — defense in depth at the Stablecoin layer ============
+    //
+    // The typed helpers (scheduleRevokeAdmin / scheduleUpgrade) catch typos at schedule time.
+    // A proposer can still bypass them by calling raw `timelock.schedule(target, value, data, ...)`
+    // with the same calldata. The Stablecoin contract itself enforces the same invariants
+    // at execute time, so the silent no-op stays closed even on the raw path.
+
+    function test_RawScheduleRevokeAdminWithNonAdminRevertsAtExecuteTime() public {
+        address typo = address(0xBADBAD);
+        assertFalse(stablecoin.hasRole(stablecoin.ADMIN_ROLE(), typo), "precondition: must not be admin");
+
+        bytes memory data = _revokeAdminCalldata(typo);
+        bytes32 salt = bytes32(uint256(35));
+
+        // Bypass the helper — go straight to the inherited schedule().
+        vm.prank(PROPOSER);
+        timelock.schedule(address(stablecoin), 0, data, bytes32(0), salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.NotAnAdmin.selector, typo));
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+    }
+
+    function test_RawScheduleUpgradeWithNonContractRevertsAtExecuteTime() public {
+        address nonContract = address(0xCAFEBABE);
+        assertEq(nonContract.code.length, 0, "precondition: address must have no code");
+
+        bytes memory data = _upgradeCalldata(nonContract, "");
+        bytes32 salt = bytes32(uint256(36));
+
+        // Bypass the helper — go straight to the inherited schedule().
+        vm.prank(PROPOSER);
+        timelock.schedule(address(stablecoin), 0, data, bytes32(0), salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.NotAContract.selector, nonContract));
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
     }
 }

--- a/test/StablecoinTimelock.t.sol
+++ b/test/StablecoinTimelock.t.sol
@@ -55,13 +55,16 @@ contract StablecoinTimelockTest is Test {
         new StablecoinTimelock(Stablecoin(address(0)), DELAY, proposers, executors, address(0));
     }
 
-    function test_RevertsOnDelayBelowFloor() public {
+    function test_AcceptsArbitraryMinDelay() public {
+        // No hardcoded floor on minDelay — operators set whatever value they want.
+        // The chosen value becomes the permanent floor via deploymentMinDelay.
         address[] memory proposers = new address[](1);
         proposers[0] = PROPOSER;
         address[] memory executors = new address[](0);
 
-        vm.expectRevert(StablecoinTimelock.DelayBelowFloor.selector);
-        new StablecoinTimelock(stablecoin, 1 days - 1, proposers, executors, address(0));
+        StablecoinTimelock shortDelay = new StablecoinTimelock(stablecoin, 1, proposers, executors, address(0));
+        assertEq(shortDelay.getMinDelay(), 1);
+        assertEq(shortDelay.deploymentMinDelay(), 1);
     }
 
     function test_RevertsOnEmptyProposers() public {
@@ -74,7 +77,7 @@ contract StablecoinTimelockTest is Test {
 
     function test_ConstructionStoresImmutableStablecoin() public {
         assertEq(address(timelock.stablecoin()), address(stablecoin));
-        assertEq(timelock.MIN_DELAY_FLOOR(), 1 days);
+        assertEq(timelock.deploymentMinDelay(), DELAY);
         assertEq(timelock.getMinDelay(), DELAY);
     }
 
@@ -430,7 +433,7 @@ contract StablecoinTimelockTest is Test {
     function test_E2E_RevokeLastAdminRevertsThroughTimelock() public {
         // Timelock is the only admin (per setUp). Scheduling revokeAdmin(timelock) is fine —
         // the timelock just queues calldata. Execution must revert with the stablecoin's
-        // LastAdminCannotBeRemoved guard.
+        // AdminRoleCannotBeEmpty guard.
         bytes32 salt = bytes32(uint256(24));
         bytes memory data = _revokeAdminCalldata(address(timelock));
 

--- a/test/StablecoinTimelock.t.sol
+++ b/test/StablecoinTimelock.t.sol
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Stablecoin} from "../src/Stablecoin.sol";
+import {StablecoinTimelock} from "../src/StablecoinTimelock.sol";
+import {
+    ERC1967Proxy
+} from "lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract StablecoinTimelockTest is Test {
+    Stablecoin internal stablecoin;
+    StablecoinTimelock internal timelock;
+
+    address internal constant ADMIN = address(0xA11CE);
+    address internal constant PROPOSER = address(0xC0DE);
+    uint256 internal constant DELAY = 1 days;
+
+    function setUp() public {
+        Stablecoin impl = new Stablecoin();
+        bytes memory initData =
+            abi.encodeCall(Stablecoin.initialize, ("Demo USD", "dUSD", 18, ADMIN, ADMIN, ADMIN, ADMIN));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        stablecoin = Stablecoin(address(proxy));
+
+        address[] memory proposers = new address[](1);
+        proposers[0] = PROPOSER;
+        address[] memory executors = new address[](1);
+        executors[0] = address(0); // open execution
+        timelock = new StablecoinTimelock(stablecoin, DELAY, proposers, executors, address(0));
+
+        vm.startPrank(ADMIN);
+        stablecoin.grantRole(stablecoin.ADMIN_ROLE(), address(timelock));
+        stablecoin.renounceRole(stablecoin.ADMIN_ROLE(), ADMIN);
+        vm.stopPrank();
+    }
+
+    // ============ setup sanity ============
+
+    function test_SetUpHandedOverAdminRole() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        assertTrue(stablecoin.hasRole(adminRole, address(timelock)));
+        assertFalse(stablecoin.hasRole(adminRole, ADMIN));
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
+    }
+
+    // ============ construction guards ============
+
+    function test_RevertsOnZeroStablecoin() public {
+        address[] memory proposers = new address[](1);
+        proposers[0] = PROPOSER;
+        address[] memory executors = new address[](0);
+
+        vm.expectRevert(StablecoinTimelock.ZeroStablecoin.selector);
+        new StablecoinTimelock(Stablecoin(address(0)), DELAY, proposers, executors, address(0));
+    }
+
+    function test_RevertsOnDelayBelowFloor() public {
+        address[] memory proposers = new address[](1);
+        proposers[0] = PROPOSER;
+        address[] memory executors = new address[](0);
+
+        vm.expectRevert(StablecoinTimelock.DelayBelowFloor.selector);
+        new StablecoinTimelock(stablecoin, 1 days - 1, proposers, executors, address(0));
+    }
+
+    function test_RevertsOnEmptyProposers() public {
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+
+        vm.expectRevert(StablecoinTimelock.NoProposers.selector);
+        new StablecoinTimelock(stablecoin, DELAY, proposers, executors, address(0));
+    }
+
+    function test_ConstructionStoresImmutableStablecoin() public {
+        assertEq(address(timelock.stablecoin()), address(stablecoin));
+        assertEq(timelock.MIN_DELAY_FLOOR(), 1 days);
+        assertEq(timelock.getMinDelay(), DELAY);
+    }
+
+    // ============ calldata helpers (for equivalence checks) ============
+
+    function _adminCalldata(address newAdmin) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.grantRole, (stablecoin.ADMIN_ROLE(), newAdmin));
+    }
+
+    function _revokeAdminCalldata(address oldAdmin) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.revokeRole, (stablecoin.ADMIN_ROLE(), oldAdmin));
+    }
+
+    function _addMinterCalldata(address minter, uint256 cap) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.addMinter, (minter, cap));
+    }
+
+    function _removeMinterCalldata(address minter) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.removeMinter, (minter));
+    }
+
+    function _modifyAllowanceCalldata(address minter, uint256 cap) internal view returns (bytes memory) {
+        return abi.encodeCall(stablecoin.modifyMinterAllowance, (minter, cap));
+    }
+
+    function _upgradeCalldata(address newImpl, bytes memory data) internal pure returns (bytes memory) {
+        return abi.encodeWithSignature("upgradeToAndCall(address,bytes)", newImpl, data);
+    }
+
+    // ============ scheduleGrantAdmin ============
+
+    function test_GrantAdminCalldataMatchesManual() public {
+        address newAdmin = address(0xAD1);
+        bytes32 salt = bytes32(uint256(1));
+
+        bytes memory expected = _adminCalldata(newAdmin);
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantAdmin(newAdmin, salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    function test_E2E_GrantAdmin() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address newAdmin = address(0xAD1);
+        bytes32 salt = bytes32(uint256(2));
+        bytes memory data = _adminCalldata(newAdmin);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantAdmin(newAdmin, salt, DELAY);
+
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertTrue(stablecoin.hasRole(adminRole, newAdmin));
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 2);
+    }
+
+    // ============ scheduleRevokeAdmin ============
+
+    function test_RevokeAdminCalldataMatchesManual() public {
+        bytes32 salt = bytes32(uint256(3));
+        bytes memory expected = _revokeAdminCalldata(address(0xAD1));
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokeAdmin(address(0xAD1), salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    function test_E2E_RevokeAdmin() public {
+        bytes32 adminRole = stablecoin.ADMIN_ROLE();
+        address otherAdmin = address(0xAD1);
+
+        // Grant first so there are two admins.
+        bytes32 grantSalt = bytes32(uint256(4));
+        bytes memory grantData = _adminCalldata(otherAdmin);
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantAdmin(otherAdmin, grantSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, grantData, bytes32(0), grantSalt);
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 2);
+
+        // Now revoke the second admin via the helper.
+        bytes32 revokeSalt = bytes32(uint256(5));
+        bytes memory revokeData = _revokeAdminCalldata(otherAdmin);
+        vm.prank(PROPOSER);
+        timelock.scheduleRevokeAdmin(otherAdmin, revokeSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, revokeData, bytes32(0), revokeSalt);
+
+        assertFalse(stablecoin.hasRole(adminRole, otherAdmin));
+        assertEq(stablecoin.getRoleMemberCount(adminRole), 1);
+    }
+
+    // ============ scheduleAddMinter ============
+
+    function test_AddMinterCalldataMatchesManual() public {
+        bytes32 salt = bytes32(uint256(6));
+        bytes memory expected = _addMinterCalldata(address(0xBEEF), 1000);
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleAddMinter(address(0xBEEF), 1000, salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    function test_E2E_AddMinter() public {
+        address minter = address(0xBEEF);
+        uint256 cap = 1000;
+        bytes32 salt = bytes32(uint256(7));
+        bytes memory data = _addMinterCalldata(minter, cap);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleAddMinter(minter, cap, salt, DELAY);
+
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        assertTrue(stablecoin.hasRole(stablecoin.MINTER_ROLE(), minter));
+        assertEq(stablecoin.minterAllowance(minter), cap);
+    }
+
+    // ============ scheduleRemoveMinter ============
+
+    function test_RemoveMinterCalldataMatchesManual() public {
+        bytes32 salt = bytes32(uint256(8));
+        bytes memory expected = _removeMinterCalldata(address(0xBEEF));
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleRemoveMinter(address(0xBEEF), salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    function test_E2E_RemoveMinter() public {
+        address minter = address(0xBEEF);
+
+        // Add the minter first.
+        bytes32 addSalt = bytes32(uint256(9));
+        bytes memory addData = _addMinterCalldata(minter, 1000);
+        vm.prank(PROPOSER);
+        timelock.scheduleAddMinter(minter, 1000, addSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, addData, bytes32(0), addSalt);
+
+        // Now remove via the helper.
+        bytes32 removeSalt = bytes32(uint256(10));
+        bytes memory removeData = _removeMinterCalldata(minter);
+        vm.prank(PROPOSER);
+        timelock.scheduleRemoveMinter(minter, removeSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, removeData, bytes32(0), removeSalt);
+
+        assertFalse(stablecoin.hasRole(stablecoin.MINTER_ROLE(), minter));
+        assertEq(stablecoin.minterAllowance(minter), 0);
+    }
+
+    // ============ scheduleModifyMinterAllowance ============
+
+    function test_ModifyMinterAllowanceCalldataMatchesManual() public {
+        bytes32 salt = bytes32(uint256(11));
+        bytes memory expected = _modifyAllowanceCalldata(address(0xBEEF), 5000);
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleModifyMinterAllowance(address(0xBEEF), 5000, salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    function test_E2E_ModifyMinterAllowance() public {
+        address minter = address(0xBEEF);
+
+        bytes32 addSalt = bytes32(uint256(12));
+        bytes memory addData = _addMinterCalldata(minter, 1000);
+        vm.prank(PROPOSER);
+        timelock.scheduleAddMinter(minter, 1000, addSalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, addData, bytes32(0), addSalt);
+
+        bytes32 modifySalt = bytes32(uint256(13));
+        bytes memory modifyData = _modifyAllowanceCalldata(minter, 5000);
+        vm.prank(PROPOSER);
+        timelock.scheduleModifyMinterAllowance(minter, 5000, modifySalt, DELAY);
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, modifyData, bytes32(0), modifySalt);
+
+        assertEq(stablecoin.minterAllowance(minter), 5000);
+    }
+
+    // ============ scheduleUpgrade ============
+
+    function test_UpgradeCalldataMatchesManual() public {
+        address newImpl = address(0xCAFEBABE);
+        bytes32 salt = bytes32(uint256(14));
+        bytes memory expected = _upgradeCalldata(newImpl, "");
+        bytes32 manualId = timelock.hashOperation(address(stablecoin), 0, expected, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleUpgrade(newImpl, "", salt, DELAY);
+
+        assertTrue(timelock.isOperation(manualId));
+    }
+
+    function test_E2E_Upgrade() public {
+        Stablecoin newImpl = new Stablecoin();
+        bytes32 salt = bytes32(uint256(15));
+        bytes memory data = _upgradeCalldata(address(newImpl), "");
+
+        vm.prank(PROPOSER);
+        timelock.scheduleUpgrade(address(newImpl), "", salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+
+        // ERC1967 implementation slot: bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1).
+        // Mirrors the constant in OZ's ERC1967Utils.IMPLEMENTATION_SLOT (internal, so not directly importable).
+        bytes32 implSlot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        address storedImpl = address(uint160(uint256(vm.load(address(stablecoin), implSlot))));
+        assertEq(storedImpl, address(newImpl));
+    }
+
+    // ============ delay enforcement ============
+
+    function test_HelperRevertsWhenDelayBelowMinDelay() public {
+        bytes32 salt = bytes32(uint256(17));
+        uint256 tooShort = DELAY - 1;
+
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSignature("TimelockInsufficientDelay(uint256,uint256)", tooShort, DELAY));
+        timelock.scheduleGrantAdmin(address(0xAD1), salt, tooShort);
+    }
+
+    // ============ cancel ============
+
+    function test_CancelScheduledOp() public {
+        address newAdmin = address(0xAD1);
+        bytes32 salt = bytes32(uint256(18));
+        bytes memory data = _adminCalldata(newAdmin);
+        bytes32 opId = timelock.hashOperation(address(stablecoin), 0, data, bytes32(0), salt);
+
+        vm.prank(PROPOSER);
+        timelock.scheduleGrantAdmin(newAdmin, salt, DELAY);
+        assertTrue(timelock.isOperation(opId));
+
+        // Proposers are granted CANCELLER_ROLE by the OZ constructor.
+        vm.prank(PROPOSER);
+        timelock.cancel(opId);
+        assertFalse(timelock.isOperation(opId));
+    }
+
+    // ============ paused stablecoin behaviour ============
+
+    function test_E2E_AddMinterRevertsWhenStablecoinPaused() public {
+        address minter = address(0xBEEF);
+        bytes32 salt = bytes32(uint256(19));
+        bytes memory data = _addMinterCalldata(minter, 1000);
+
+        // Pause the stablecoin (ADMIN retained PAUSER_ROLE through setUp).
+        vm.prank(ADMIN);
+        stablecoin.pause();
+
+        // Scheduling still succeeds — the timelock only queues calldata.
+        vm.prank(PROPOSER);
+        timelock.scheduleAddMinter(minter, 1000, salt, DELAY);
+
+        // Execution after the delay reverts because addMinter is whenNotPaused.
+        vm.warp(block.timestamp + DELAY + 1);
+        vm.expectRevert();
+        timelock.execute(address(stablecoin), 0, data, bytes32(0), salt);
+    }
+
+    // ============ updateDelay floor ============
+
+    function test_UpdateDelayCannotGoBelowDeployedFloor() public {
+        // Schedule a self-call to updateDelay(0). Scheduling succeeds; the floor
+        // is enforced at execute-time by our override.
+        bytes memory data = abi.encodeCall(timelock.updateDelay, (uint256(0)));
+        bytes32 salt = bytes32(uint256(20));
+
+        vm.prank(PROPOSER);
+        timelock.schedule(address(timelock), 0, data, bytes32(0), salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        vm.expectRevert();
+        timelock.execute(address(timelock), 0, data, bytes32(0), salt);
+
+        assertEq(timelock.getMinDelay(), DELAY);
+        assertEq(timelock.deploymentMinDelay(), DELAY);
+    }
+
+    function test_UpdateDelayCanRaiseAboveDeployedFloor() public {
+        uint256 raised = 7 days;
+        bytes memory data = abi.encodeCall(timelock.updateDelay, (raised));
+        bytes32 salt = bytes32(uint256(21));
+
+        vm.prank(PROPOSER);
+        timelock.schedule(address(timelock), 0, data, bytes32(0), salt, DELAY);
+
+        vm.warp(block.timestamp + DELAY + 1);
+        timelock.execute(address(timelock), 0, data, bytes32(0), salt);
+
+        assertEq(timelock.getMinDelay(), raised);
+        assertEq(timelock.deploymentMinDelay(), DELAY);
+    }
+
+    // ============ access control ============
+
+    function test_NonProposerCannotCallHelpers() public {
+        address nonProposer = address(0xDEAD);
+        bytes32 salt = bytes32(uint256(16));
+
+        bytes memory expectedError = abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)", nonProposer, timelock.PROPOSER_ROLE()
+        );
+
+        vm.prank(nonProposer);
+        vm.expectRevert(expectedError);
+        timelock.scheduleGrantAdmin(address(0xAD1), salt, DELAY);
+    }
+}

--- a/test/StablecoinTimelock.t.sol
+++ b/test/StablecoinTimelock.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
 import {Test} from "forge-std/Test.sol";

--- a/test/UpgradeStablecoin.t.sol
+++ b/test/UpgradeStablecoin.t.sol
@@ -394,9 +394,10 @@ contract UpgradeStablecoinTest is Test {
         bytes memory reinitData = abi.encodeCall(StablecoinV2.initializeV2, (MAX_SUPPLY));
         address eoa = address(0xDEAD);
 
-        // UUPS calls proxiableUUID() on the target first, which reverts on a non-contract address
+        // Stablecoin._authorizeUpgrade rejects non-contract implementations with
+        // NotAContract before reaching UUPSUpgradeable's proxiableUUID staticcall.
         vm.prank(ADMIN);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.NotAContract.selector, eoa));
         UUPSUpgradeable(proxy).upgradeToAndCall(eoa, reinitData);
     }
 


### PR DESCRIPTION
 In the previous code, Stablecoin.initialize set the admin of `BURNER_ROLE`/`PAUSER_ROLE`/`FREEZER_ROLE` but never configured an admin for ADMIN_ROLE itself, so it defaulted to DEFAULT_ADMIN_ROLE — a role held by no account. grantRole(ADMIN_ROLE, …) and revokeRole(ADMIN_ROLE, …) always reverted, while the inherited renounceRole still allowed the sole admin to renounce, potentially leaving the role with zero members and the contract permanently unrecoverable (no minter management, no upgrades, no role rotation).

This PR makes ADMIN_ROLE rotatable on-chain and ships a purpose-built TimelockController so production deployments can route every admin operation through a delayed-execution governance contract.

It also gates the rest of admin operations (setting the rest of the roles) under the timelock.