### PR TITLE
Fix minter renounce clears allowance

### DIFF
--- a/src/Stablecoin.sol
+++ b/src/Stablecoin.sol
@@ -238,17 +238,15 @@ contract Stablecoin is
         emit MinterAdded(newMinter, allowance);
     }
 
-    /// @dev Revokes MINTER_ROLE and clears the minting allowance atomically.
-    /// _revokeRole returns false when the role was not held, so the pre-check via
-    /// hasRole is redundant.
+    /// @dev Revokes MINTER_ROLE. Allowance clearing and the `MinterRemoved` event
+    /// are emitted from the centralized `_revokeRole` override below, so this
+    /// function only needs to guard against revoking a non-minter.
     ///
     /// Available while paused so an emergency response (pause) does not block emergency
     /// revocation of a suspected-compromised minter. Token movements are still blocked
     /// by `_update`'s pause check, so this does not open a new token-flow path.
     function removeMinter(address minter) public onlyRole(ADMIN_ROLE) {
         require(_revokeRole(MINTER_ROLE, minter), MinterDoesNotExist(minter));
-        delete _minterAllowances[minter];
-        emit MinterRemoved(minter);
     }
 
     /// @dev Applies a signed `delta` to the minter's allowance, relative to its current value.
@@ -380,11 +378,25 @@ contract Stablecoin is
     }
 
     /// @dev Centralized revoke hook for both `revokeRole` and `renounceRole`.
+    ///
     /// For ADMIN_ROLE: rejects revocations targeting a non-holder (closes OZ's
     /// silent-no-op path, which would otherwise mask a typo'd address after a
     /// matured timelock window) and refuses to remove the last remaining
     /// holder (ADMIN_ROLE is its own admin, so a zero-admin state is
-    /// unrecoverable on-chain). For other roles, behaves like OZ.
+    /// unrecoverable on-chain).
+    ///
+    /// For MINTER_ROLE: clears `_minterAllowances[account]` and emits
+    /// `MinterRemoved` whenever a revoke actually changes role state, so the
+    /// bookkeeping stays in sync regardless of whether the revoke flowed
+    /// through `removeMinter` (admin) or `renounceRole` (minter self-renounce).
+    /// Without this branch the renounce path leaves a stale allowance entry
+    /// and subsequent `removeMinter` / `modifyMinterAllowance` calls revert
+    /// with `MinterDoesNotExist` — observable as a permanent slot leak in
+    /// `getAllMinters()` and operator tooling.
+    ///
+    /// The branch is gated on `super._revokeRole(...) == true` so a
+    /// `renounceRole(MINTER_ROLE, nonMinter)` no-op does NOT emit a spurious
+    /// `MinterRemoved`.
     function _revokeRole(bytes32 role, address account)
         internal
         override(AccessControlEnumerableUpgradeable)
@@ -394,6 +406,11 @@ contract Stablecoin is
             if (!hasRole(ADMIN_ROLE, account)) revert NotAnAdmin(account);
             if (getRoleMemberCount(ADMIN_ROLE) == 1) revert AdminRoleCannotBeEmpty();
         }
-        return super._revokeRole(role, account);
+        bool revoked = super._revokeRole(role, account);
+        if (revoked && role == MINTER_ROLE) {
+            delete _minterAllowances[account];
+            emit MinterRemoved(account);
+        }
+        return revoked;
     }
 }

--- a/test/Stablecoin.t.sol
+++ b/test/Stablecoin.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity =0.8.30;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Stablecoin} from "../src/Stablecoin.sol";
 import {
     ERC1967Proxy
@@ -1529,5 +1529,74 @@ contract StablecoinTest is Test {
         vm.prank(newMinter);
         vm.expectRevert(expectedError);
         stablecoin.mint(address(2), 100);
+    }
+
+    /// @notice A minter who renounces MINTER_ROLE leaves no stale allowance state behind.
+    /// `_revokeRole` clears `_minterAllowances` and emits `MinterRemoved`, so the address
+    /// is fully cleaned up and can be re-added with `addMinter` afterwards.
+    function test_RenounceMinterClearsAllowanceAndEmits() public {
+        // MINTER was added in setUp with allowance 1000.
+        bytes32 minterRole = stablecoin.MINTER_ROLE();
+        assertTrue(stablecoin.hasRole(minterRole, MINTER));
+        assertEq(stablecoin.minterAllowance(MINTER), 1000);
+
+        vm.prank(MINTER);
+        vm.expectEmit();
+        emit Stablecoin.MinterRemoved(MINTER);
+        stablecoin.renounceRole(minterRole, MINTER);
+
+        // Role gone, allowance cleared, no longer enumerated.
+        assertFalse(stablecoin.hasRole(minterRole, MINTER));
+        assertEq(stablecoin.minterAllowance(MINTER), 0);
+        assertEq(stablecoin.getMinterCount(), 0);
+
+        // Subsequent admin ops on the renounced address surface a clean error.
+        vm.prank(ADMIN);
+        vm.expectPartialRevert(Stablecoin.MinterDoesNotExist.selector);
+        stablecoin.removeMinter(MINTER);
+
+        // Re-adding works cleanly — fresh slot, fresh allowance.
+        vm.prank(ADMIN);
+        stablecoin.addMinter(MINTER, 4242);
+        assertEq(stablecoin.minterAllowance(MINTER), 4242);
+    }
+
+    /// @notice `removeMinter` emits exactly one `MinterRemoved` event after the centralization
+    /// in `_revokeRole` (no double-emit).
+    function test_RemoveMinterSingleEmit() public {
+        vm.prank(ADMIN);
+        vm.recordLogs();
+        stablecoin.removeMinter(MINTER);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 count = 0;
+        bytes32 topic = keccak256("MinterRemoved(address)");
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == topic) {
+                ++count;
+            }
+        }
+        assertEq(count, 1, "expected exactly one MinterRemoved emission");
+    }
+
+    /// @notice Renouncing MINTER_ROLE on an address that doesn't hold it is a no-op:
+    /// OZ's `_revokeRole` returns false, our override skips the cleanup, and no
+    /// spurious `MinterRemoved` is emitted.
+    function test_RenounceMinterByNonMinterDoesNotEmit() public {
+        address nonMinter = address(0xBEEF);
+        bytes32 minterRole = stablecoin.MINTER_ROLE();
+        assertFalse(stablecoin.hasRole(minterRole, nonMinter));
+
+        vm.recordLogs();
+        vm.prank(nonMinter);
+        stablecoin.renounceRole(minterRole, nonMinter);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 minterRemovedTopic = keccak256("MinterRemoved(address)");
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == minterRemovedTopic) {
+                fail("unexpected MinterRemoved emission for non-minter renounce");
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR centralizes the bookkeeping in the existing `_revokeRole` override. The new `MINTER_ROLE` branch clears `_minterAllowances[account]` and emits `MinterRemoved(account)` whenever `super._revokeRole` actually changes role state (gated on `revoked == true` so a no-op renounce doesn't emit a spurious event). 

`removeMinter` drops its now-redundant `delete` and `emit`.