### PR TITLE
Fix replay binding to source message

### DIFF
--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -8,8 +8,10 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IInbox} from "./interfaces/IInbox.sol";
 import {IMessageReceiver} from "./interfaces/IMessageReceiver.sol";
+import {IOutbox} from "./interfaces/IOutbox.sol";
 
 /// @title Inbox
 /// @notice Generic message inbox with k-of-n EIP-712 attestor verification, nonce replay protection,
@@ -40,6 +42,13 @@ contract Inbox is
     /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fcbae5394ae8ad52d8e580a3477db99814b9d565/contracts/utils/ReentrancyGuard.sol#L39-L43
     mapping(bytes32 nonce => uint256 used) public usedNonces;
 
+    /// @notice Per-source-chain canonical Outbox address. A message is only accepted
+    /// when its `srcOutbox` field equals `srcOutboxes[srcChain]`. This enforces the
+    /// "one canonical Outbox per source chain" invariant on which the nonce
+    /// derivation depends — the nonce includes `srcOutbox`, so a quorum that signs
+    /// for a stranger Outbox produces a nonce that the Inbox refuses to recognize.
+    mapping(uint256 srcChain => address outbox) public srcOutboxes;
+
     /// @notice Emitted on every successful `recvMessage` delivery.
     event MessageDelivered(bytes32 indexed nonce, address indexed dstRecipient);
     /// @notice Emitted when an address is added to the attestor set.
@@ -48,6 +57,8 @@ contract Inbox is
     event AttestorRemoved(address indexed attestor);
     /// @notice Emitted when the signature threshold is updated.
     event ThresholdSet(uint256 threshold);
+    /// @notice Emitted when the canonical Outbox for `srcChain` is configured or replaced.
+    event SrcOutboxSet(uint256 indexed srcChain, address outbox);
 
     error InvalidSignatureCount();
     error BelowThreshold();
@@ -59,6 +70,22 @@ contract Inbox is
     error AlreadyAttestor(address attestor);
     error NotAttestor(address attestor);
     error InvalidThreshold(uint256 threshold, uint256 attestorCount);
+    /// @notice Thrown by `setSrcOutbox` when a non-zero entry already exists for
+    /// `srcChain`. Operators must explicitly clear the entry (set to `address(0)`)
+    /// during a paused-and-drained window before pointing at a new Outbox; this
+    /// guards against the "swap Outbox while messages are in flight" footgun, in
+    /// which already-signed messages reference the old `srcOutbox` and would be
+    /// rejected silently after the swap.
+    error SrcOutboxAlreadySet(uint256 srcChain, address current);
+    /// @notice Thrown by `recvMessage` when the message's `srcOutbox` does not
+    /// match the configured `srcOutboxes[srcChain]`. Without this check, attestors
+    /// could sign messages that claim to originate from any Outbox; with it, the
+    /// derived nonce is only valid when computed against the canonical source
+    /// Outbox.
+    error UnknownSrcOutbox(uint256 srcChain, address claimed, address expected);
+    /// @notice Thrown by `setSrcOutbox` when the candidate has no bytecode or
+    /// does not advertise `IOutbox` via ERC-165. Mirrors `BridgeBurner._validateOutbox`.
+    error InvalidOutbox(address outbox);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -125,22 +152,77 @@ contract Inbox is
         emit ThresholdSet(threshold_);
     }
 
+    /// @notice Configure or clear the canonical Outbox address for a source chain.
+    /// @dev Pass `outbox = address(0)` to clear a route — this is the operator-side
+    /// step required before swapping a chain's Outbox: pause, drain in-flight, clear
+    /// here, then set the new Outbox.
+    ///
+    /// When setting a non-zero outbox, the candidate must (a) have bytecode and
+    /// (b) advertise `IOutbox` via ERC-165. The two checks mirror
+    /// `BridgeBurner._validateOutbox` and catch the most common operator typos
+    /// (EOA, unrelated contract, undeployed CREATE2 target).
+    ///
+    /// Refuses to overwrite a non-zero entry — the operator must clear first.
+    /// This prevents the silent "swap Outbox while messages are in flight" footgun.
+    /// @param srcChain Source chain id whose Outbox to (re)configure.
+    /// @param outbox  Canonical Outbox address on that chain, or `address(0)` to clear.
+    function setSrcOutbox(uint256 srcChain, address outbox) external onlyOwner {
+        address current = srcOutboxes[srcChain];
+        if (outbox == address(0)) {
+            srcOutboxes[srcChain] = address(0);
+            emit SrcOutboxSet(srcChain, address(0));
+            return;
+        }
+        require(current == address(0), SrcOutboxAlreadySet(srcChain, current));
+        _validateOutbox(outbox);
+        srcOutboxes[srcChain] = outbox;
+        emit SrcOutboxSet(srcChain, outbox);
+    }
+
+    /// @dev Validate that `outbox_` is a contract advertising `IOutbox` via ERC-165.
+    /// Same shape as `BridgeBurner._validateOutbox` — the explicit `code.length`
+    /// check routes EOAs through `InvalidOutbox` instead of solc's lower-level
+    /// "call to non-contract address" revert that try/catch does not catch.
+    function _validateOutbox(address outbox_) internal view {
+        require(outbox_.code.length > 0, InvalidOutbox(outbox_));
+        try IERC165(outbox_).supportsInterface(type(IOutbox).interfaceId) returns (bool ok) {
+            require(ok, InvalidOutbox(outbox_));
+        } catch {
+            revert InvalidOutbox(outbox_);
+        }
+    }
+
     // ─── Message reception ───────────────────────────────────────────
 
     /// @inheritdoc IInbox
     function recvMessage(bytes calldata message, bytes calldata signatures) external whenNotPaused {
-        // Decode the transport-level message
+        // Decode the transport-level message. The transport nonce is not part of
+        // the wire format — it is derived from a subset of the signed fields, so
+        // attestors cannot choose it independently of the source event.
         (
             uint256 srcChain,
+            address srcOutbox,
             address srcSender,
+            uint256 srcSeq,
             uint256 dstChain,
             address dstRecipient,
-            bytes32 nonce,
             bytes memory payload
-        ) = abi.decode(message, (uint256, address, uint256, address, bytes32, bytes));
+        ) = abi.decode(message, (uint256, address, address, uint256, uint256, address, bytes));
 
         // Check destination chain
         require(dstChain == block.chainid, WrongDestinationChain(block.chainid, dstChain));
+
+        // Authenticate the source Outbox: must match the canonical entry for `srcChain`.
+        // A zero entry (route disabled) or a different entry both reject the message.
+        address expectedOutbox = srcOutboxes[srcChain];
+        require(
+            expectedOutbox != address(0) && srcOutbox == expectedOutbox,
+            UnknownSrcOutbox(srcChain, srcOutbox, expectedOutbox)
+        );
+
+        // Derive the replay-protection nonce. Must use the SAME field encoding as
+        // `Outbox.sendMessage` so a valid source event produces a matching key.
+        bytes32 nonce = keccak256(abi.encode(srcChain, srcOutbox, srcSender, srcSeq));
 
         // Check nonce replay
         require(usedNonces[nonce] == 0, NonceAlreadyUsed(nonce));

--- a/src/bridge/Outbox.sol
+++ b/src/bridge/Outbox.sol
@@ -9,10 +9,22 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IOutbox} from "./interfaces/IOutbox.sol";
 
 /// @title Outbox
-/// @notice Generic message outbox. Accepts messages and emits events for the off-chain attestation service.
-/// Stateless: does not track messages or nonces.
+/// @notice Generic message outbox. Accepts messages, assigns a per-sender sequence
+/// number, derives a source-bound nonce, and emits an event for the off-chain
+/// attestation service.
+///
+/// The Outbox is stateful: it maintains one monotonic counter per `msg.sender`.
+/// The counter is the input the destination Inbox needs to recompute and verify
+/// the replay-protection nonce; without it, attestors could sign multiple valid
+/// attestations for the same source event under different transport nonces.
+///
 /// @custom:security-contact security@lambdaclass.com
 contract Outbox is Initializable, Ownable2StepUpgradeable, PausableUpgradeable, UUPSUpgradeable, IOutbox {
+    /// @notice Per-sender monotonic counter consumed by `sendMessage`. Each
+    /// application contract (e.g., BridgeBurner) has its own counter, so two
+    /// senders cannot collide on `srcSeq` even though they share an Outbox.
+    mapping(address sender => uint256 seq) public nextSeq;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -26,8 +38,20 @@ contract Outbox is Initializable, Ownable2StepUpgradeable, PausableUpgradeable, 
     }
 
     /// @inheritdoc IOutbox
-    function sendMessage(uint256 dstChain, address dstRecipient, bytes calldata payload) external whenNotPaused {
-        emit MessageSent(msg.sender, dstChain, dstRecipient, payload);
+    function sendMessage(uint256 dstChain, address dstRecipient, bytes calldata payload)
+        external
+        whenNotPaused
+        returns (uint256 srcSeq, bytes32 nonce)
+    {
+        srcSeq = nextSeq[msg.sender];
+        // Bind the nonce to the (source chain, source Outbox, source sender, srcSeq) tuple.
+        // The Inbox on the destination chain recomputes this and uses it as the replay key,
+        // so attestors cannot produce a valid attestation for any nonce other than this one.
+        nonce = keccak256(abi.encode(block.chainid, address(this), msg.sender, srcSeq));
+        // Effects before further interactions — even though we don't make any here, this
+        // ordering keeps the contract reentrancy-safe if a future change introduces one.
+        nextSeq[msg.sender] = srcSeq + 1;
+        emit MessageSent(msg.sender, dstChain, dstRecipient, srcSeq, nonce, payload);
     }
 
     /// @notice ERC-165 marker so consumers (e.g. BridgeBurner) can verify they have

--- a/src/bridge/deploy/BridgeConfig.sol
+++ b/src/bridge/deploy/BridgeConfig.sol
@@ -18,12 +18,23 @@ library BridgeConfig {
         address minter;
     }
 
+    /// @notice Maps a source chain id to the canonical Outbox address on that chain.
+    /// Required by the Inbox's replay-protection check. The address bytes are the
+    /// source chain's Outbox proxy; under the standard deterministic-deploy flow
+    /// this equals the *local* Outbox address, since all chains share the same
+    /// CREATE2 derivation.
+    struct SrcOutbox {
+        uint256 srcChain;
+        address outbox;
+    }
+
     struct Config {
         address[] attestors;
         uint256 threshold;
         uint256 minterAllowance;
         AllowedSender[] allowedSenders;
         DstMinter[] dstMinters;
+        SrcOutbox[] srcOutboxes;
     }
 
     error NoAttestors();
@@ -32,6 +43,7 @@ library BridgeConfig {
     error MinterAllowanceZero();
     error ZeroAllowedSender(uint256 index);
     error ZeroDstMinter(uint256 index);
+    error ZeroSrcOutbox(uint256 index);
 
     /// @notice Configure all bridge contracts after deployment.
     /// @dev The caller must have ADMIN_ROLE on the stablecoin and be the owner of
@@ -66,6 +78,15 @@ library BridgeConfig {
         for (uint256 i = 0; i < config.dstMinters.length; ++i) {
             c.bridgeBurner.setDstMinter(config.dstMinters[i].dstChain, config.dstMinters[i].minter);
         }
+
+        // 6. Set Inbox source-outbox map (srcChain => canonical Outbox on that chain).
+        //    Required by the replay-protection check: the Inbox derives the replay
+        //    nonce from `(srcChain, srcOutbox, srcSender, srcSeq)`, so the expected
+        //    `srcOutbox` per chain must be configured before any message from that
+        //    chain can be received.
+        for (uint256 i = 0; i < config.srcOutboxes.length; ++i) {
+            c.inbox.setSrcOutbox(config.srcOutboxes[i].srcChain, config.srcOutboxes[i].outbox);
+        }
     }
 
     /// @dev Validate the entire config before any state changes, so configure either
@@ -88,6 +109,9 @@ library BridgeConfig {
         }
         for (uint256 i = 0; i < config.dstMinters.length; ++i) {
             require(config.dstMinters[i].minter != address(0), ZeroDstMinter(i));
+        }
+        for (uint256 i = 0; i < config.srcOutboxes.length; ++i) {
+            require(config.srcOutboxes[i].outbox != address(0), ZeroSrcOutbox(i));
         }
     }
 }

--- a/src/bridge/interfaces/IInbox.sol
+++ b/src/bridge/interfaces/IInbox.sol
@@ -6,7 +6,11 @@ pragma solidity =0.8.30;
 interface IInbox {
     /// @notice Verify attestor signatures and deliver a message to the destination receiver.
     ///         The message is delivered as an `IMessageReceiver.handleMessage` call to the recipient.
-    /// @param message ABI-encoded (srcChain, srcSender, dstChain, dstRecipient, nonce, payload).
+    /// @param message ABI-encoded
+    ///         (srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload).
+    ///         The transport nonce is not part of the wire format: the Inbox
+    ///         recomputes `nonce = keccak256(srcChain, srcOutbox, srcSender, srcSeq)`
+    ///         and uses it as the replay-protection key.
     /// @param signatures Packed ECDSA signatures (65 bytes each: r[32] || s[32] || v[1]).
     function recvMessage(bytes calldata message, bytes calldata signatures) external;
 

--- a/src/bridge/interfaces/IOutbox.sol
+++ b/src/bridge/interfaces/IOutbox.sol
@@ -3,13 +3,41 @@ pragma solidity =0.8.30;
 
 /// @title IOutbox
 /// @notice Interface for the generic message outbox.
+/// @dev Each `MessageSent` event carries a per-sender sequence number AND a
+/// derived nonce. The Inbox on the destination chain recomputes the nonce from
+/// `(srcChain, srcOutbox, srcSender, srcSeq)` and uses it as the replay-protection
+/// key, so attestors cannot choose the nonce independently of the source event.
 interface IOutbox {
     /// @notice Emitted when a message is sent to a destination chain.
-    event MessageSent(address indexed sender, uint256 indexed dstChain, address indexed dstRecipient, bytes payload);
+    /// @param sender The application contract calling `sendMessage` (e.g., BridgeBurner).
+    /// @param dstChain Chain ID of the destination chain.
+    /// @param dstRecipient Address of the receiver contract on the destination chain.
+    /// @param srcSeq Per-sender monotonic sequence number assigned by this Outbox.
+    /// @param nonce `keccak256(abi.encode(srcChain, srcOutbox, sender, srcSeq))` —
+    /// emitted for off-chain observability; the Inbox recomputes it from the same
+    /// fields in the signed message envelope.
+    /// @param payload Application-level data, opaque to the transport layer.
+    event MessageSent(
+        address indexed sender,
+        uint256 indexed dstChain,
+        address indexed dstRecipient,
+        uint256 srcSeq,
+        bytes32 nonce,
+        bytes payload
+    );
 
     /// @notice Send a message to a contract on a destination chain.
     /// @param dstChain Chain ID of the destination chain.
     /// @param dstRecipient Address of the receiver contract on the destination chain.
     /// @param payload Application-level data, opaque to the transport layer.
-    function sendMessage(uint256 dstChain, address dstRecipient, bytes calldata payload) external;
+    /// @return srcSeq Per-sender sequence number assigned to this message.
+    /// @return nonce Derived nonce — see the `MessageSent` event docs.
+    function sendMessage(uint256 dstChain, address dstRecipient, bytes calldata payload)
+        external
+        returns (uint256 srcSeq, bytes32 nonce);
+
+    /// @notice Current sequence number assigned to the next message from `sender`.
+    /// @param sender Application contract whose counter to read.
+    /// @return Next sequence number that `sendMessage` would consume.
+    function nextSeq(address sender) external view returns (uint256);
 }

--- a/test/bridge/Bridge.formal.t.sol
+++ b/test/bridge/Bridge.formal.t.sol
@@ -116,15 +116,27 @@ contract FormalTestBase is Test {
         }
     }
 
+    /// @dev H-04 wire format: (srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload).
+    /// The Inbox recomputes the replay nonce from (srcChain, srcOutbox, srcSender, srcSeq).
     function _encodeMessage(
         uint256 srcChain,
+        address srcOutbox,
         address srcSender,
+        uint256 srcSeq,
         uint256 dstChain,
         address dstRecipient,
-        bytes32 nonce,
         bytes memory payload
     ) internal pure returns (bytes memory) {
-        return abi.encode(srcChain, srcSender, dstChain, dstRecipient, nonce, payload);
+        return abi.encode(srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload);
+    }
+
+    /// @dev Mirror of the Inbox's nonce derivation, for proofs that assert on `usedNonces`.
+    function _deriveNonce(uint256 srcChain, address srcOutbox, address srcSender, uint256 srcSeq)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(srcChain, srcOutbox, srcSender, srcSeq));
     }
 }
 
@@ -137,6 +149,11 @@ contract FormalTestBase is Test {
 contract InboxFormalTest is FormalTestBase {
     AlwaysSucceedsReceiver public receiver;
 
+    /// @dev Concrete source chain id used by the proofs; its canonical Outbox is
+    /// configured in setUp so messages pass the H-04 `srcOutboxes` check.
+    uint256 internal constant SRC_CHAIN = 42;
+    address internal constant SRC_SENDER = address(0xAAAA);
+
     function setUp() public override {
         super.setUp();
         receiver = new AlwaysSucceedsReceiver();
@@ -146,22 +163,28 @@ contract InboxFormalTest is FormalTestBase {
         inbox.addAttestor(attestor2);
         inbox.addAttestor(attestor3);
         inbox.setThreshold(2);
+        // H-04: register the canonical source Outbox for SRC_CHAIN so deliveries
+        // pass the srcOutbox authentication and reach the property under test.
+        inbox.setSrcOutbox(SRC_CHAIN, address(outbox));
         vm.stopPrank();
     }
 
     // ─── Nonce replay protection ──────────────────────────────────────────────
 
-    /// @notice PROOF: For ALL nonces, once consumed, replaying the same message
-    /// always reverts.
-    function check_nonceReplayAlwaysReverts(bytes32 nonce) public {
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+    /// @notice PROOF: For ALL source sequence numbers, once a message is consumed,
+    /// replaying the same message always reverts. The replay key is the H-04
+    /// derived nonce `keccak256(srcChain, srcOutbox, srcSender, srcSeq)`.
+    function check_nonceReplayAlwaysReverts(uint256 srcSeq) public {
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq, block.chainid, address(receiver), hex"");
+        bytes32 nonce = _deriveNonce(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq);
 
         uint256[] memory pks = new uint256[](2);
         pks[0] = ATTESTOR_PK_1;
         pks[1] = ATTESTOR_PK_2;
         bytes memory sigs = _signMessage(message, pks);
 
-        // First delivery consumes the nonce
+        // First delivery consumes the derived nonce
         inbox.recvMessage(message, sigs);
         assert(inbox.usedNonces(nonce) == 1);
 
@@ -172,21 +195,17 @@ contract InboxFormalTest is FormalTestBase {
 
     // ─── Destination chain enforcement ────────────────────────────────────────
 
-    /// @notice PROOF: Messages targeting a different chain ALWAYS revert,
-    /// for ALL message contents and ALL signature bytes.
-    ///
-    /// The chain check (Inbox L121) is the first validation after decoding,
-    /// so no combination of other fields or signatures can bypass it.
-    function check_wrongChainAlwaysReverts(
-        uint256 srcChain,
-        address srcSender,
-        uint256 dstChain,
-        address dstRecipient,
-        bytes32 nonce
-    ) public {
+    /// @notice PROOF: Messages targeting a different chain ALWAYS revert. The
+    /// destination-chain check is the first validation after decoding and does not
+    /// depend on any other field, so it is sufficient to symbolically vary `dstChain`
+    /// while holding the remaining fields concrete (a configured, otherwise-valid
+    /// message). Keeping the other fields concrete also avoids a Halmos
+    /// symbolic-CALLDATACOPY limitation when decoding a fully-symbolic envelope.
+    function check_wrongChainAlwaysReverts(uint256 dstChain) public {
         vm.assume(dstChain != block.chainid);
 
-        bytes memory message = _encodeMessage(srcChain, srcSender, dstChain, dstRecipient, nonce, hex"");
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(outbox), SRC_SENDER, 0, dstChain, address(receiver), hex"");
 
         (bool success,) = address(inbox).call(abi.encodeCall(inbox.recvMessage, (message, hex"")));
         assert(!success);
@@ -202,13 +221,19 @@ contract InboxFormalTest is FormalTestBase {
     /// @dev `Inbox.setThreshold` now refuses `threshold_ == 0` (PR #4 invariant),
     /// so we exercise the implicit zero state by deploying a fresh Inbox whose
     /// `threshold` has never been set rather than calling `setThreshold(0)`.
-    function check_zeroThresholdFailsClosed(bytes32 nonce) public {
+    function check_zeroThresholdFailsClosed(uint256 srcSeq) public {
         Inbox freshInboxImpl = new Inbox();
         ERC1967Proxy freshInboxProxy =
             new ERC1967Proxy(address(freshInboxImpl), abi.encodeCall(Inbox.initialize, (ADMIN)));
         Inbox freshInbox = Inbox(address(freshInboxProxy));
 
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        // Configure the source Outbox so the message clears the srcOutbox check and
+        // reaches the (unconfigured, zero) threshold check — the property under test.
+        vm.prank(ADMIN);
+        freshInbox.setSrcOutbox(SRC_CHAIN, address(outbox));
+
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq, block.chainid, address(receiver), hex"");
 
         // 130 zero bytes: passes length alignment but reaches the threshold check.
         bytes memory sigs = new bytes(130);
@@ -222,8 +247,9 @@ contract InboxFormalTest is FormalTestBase {
     /// @notice PROOF: A single 65-byte signature when threshold = 2 ALWAYS reverts.
     /// Proves the `sigCount >= threshold` check (Inbox L154).
     /// Uses dummy bytes (not valid sigs) since the count check precedes recovery.
-    function check_singleSigBelowThresholdReverts(bytes32 nonce) public {
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+    function check_singleSigBelowThresholdReverts(uint256 srcSeq) public {
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq, block.chainid, address(receiver), hex"");
 
         // 65 zero bytes: passes length alignment (L153) but fails sigCount >= 2 (L154)
         bytes memory sigs = new bytes(65);
@@ -233,8 +259,9 @@ contract InboxFormalTest is FormalTestBase {
     }
 
     /// @notice PROOF: Zero-length signatures ALWAYS revert.
-    function check_zeroSignaturesReverts(bytes32 nonce) public {
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+    function check_zeroSignaturesReverts(uint256 srcSeq) public {
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq, block.chainid, address(receiver), hex"");
 
         (bool success,) = address(inbox).call(abi.encodeCall(inbox.recvMessage, (message, hex"")));
         assert(!success);
@@ -242,11 +269,14 @@ contract InboxFormalTest is FormalTestBase {
 
     // ─── Delivery postcondition ───────────────────────────────────────────────
 
-    /// @notice PROOF: For ALL nonces, successful delivery sets usedNonces[nonce] = 1.
-    function check_deliveryConsumesNonce(bytes32 nonce) public {
+    /// @notice PROOF: For ALL source sequence numbers, successful delivery sets
+    /// `usedNonces[derivedNonce] = 1`.
+    function check_deliveryConsumesNonce(uint256 srcSeq) public {
+        bytes32 nonce = _deriveNonce(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq);
         assert(inbox.usedNonces(nonce) == 0);
 
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(outbox), SRC_SENDER, srcSeq, block.chainid, address(receiver), hex"");
 
         uint256[] memory pks = new uint256[](2);
         pks[0] = ATTESTOR_PK_1;

--- a/test/bridge/Bridge.integration.t.sol
+++ b/test/bridge/Bridge.integration.t.sol
@@ -50,7 +50,13 @@ contract BridgeIntegrationTest is Test {
     address public attestor3;
     address public user;
 
-    uint256 public nonceCounter;
+    /// @dev The transport nonce is a derived field. Tests bump a `srcSeq` counter
+    /// that the helpers feed into the message; the Inbox recomputes the nonce as
+    /// `keccak256(srcChain, srcOutbox, srcSender, srcSeq)`. The counter
+    /// is purely test-local — the Outbox's per-sender counter (incremented inside
+    /// `sendTo`) is separate and unused here, because the tests construct
+    /// messages directly rather than picking up the Outbox-emitted nonce.
+    uint256 public srcSeqCounter;
 
     function setUp() public {
         attestor1 = vm.addr(ATTESTOR_PK_1);
@@ -171,27 +177,27 @@ contract BridgeIntegrationTest is Test {
         chainA.bridge.bridgeBurner.sendTo(CHAIN_B, recipient, amount2);
         vm.stopPrank();
 
-        // Deliver msg2 first, then msg1 (different nonces, both succeed)
-        bytes32 nonce1 = _nextNonce();
-        bytes32 nonce2 = _nextNonce();
+        // Deliver msg2 first, then msg1 (different srcSeqs → different derived nonces).
+        uint256 seq1 = _nextSeq();
+        uint256 seq2 = _nextSeq();
 
-        _deliverMessageWithNonce(
+        _deliverMessageWithSeq(
             chainA,
             chainB,
             address(chainA.bridge.bridgeBurner),
             address(chainB.bridge.bridgeMinter),
             recipient,
             amount2,
-            nonce2
+            seq2
         );
-        _deliverMessageWithNonce(
+        _deliverMessageWithSeq(
             chainA,
             chainB,
             address(chainA.bridge.bridgeBurner),
             address(chainB.bridge.bridgeMinter),
             recipient,
             amount1,
-            nonce1
+            seq1
         );
 
         assertEq(chainB.stablecoin.balanceOf(recipient), amount1 + amount2);
@@ -211,19 +217,22 @@ contract BridgeIntegrationTest is Test {
 
         // Try to deliver on chain C (dstChain=B but delivering to C's inbox)
         bytes memory payload = TokenMintMessage.encode(recipient, amount);
-        bytes32 nonce = _nextNonce();
-        // Message specifies dstChain=CHAIN_B but we're delivering to chain C
+        // Message format: (srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload)
         bytes memory message = abi.encode(
-            CHAIN_A, address(chainA.bridge.bridgeBurner), CHAIN_B, address(chainC.bridge.bridgeMinter), nonce, payload
+            CHAIN_A,
+            address(chainA.bridge.outbox),
+            address(chainA.bridge.bridgeBurner),
+            _nextSeq(),
+            CHAIN_B,
+            address(chainC.bridge.bridgeMinter),
+            payload
         );
 
         // Sign for chain C's inbox (but message says dstChain=B)
         bytes memory sigs = _signForInbox(chainC.bridge.inbox, message);
 
-        // Chain C's inbox checks dstChain == block.chainid (which we set to CHAIN_C)
-        // Since message has dstChain=CHAIN_B and we deliver to a VM with chainid=CHAIN_C... but
-        // in a single Foundry VM block.chainid is the same for all. So we check the WrongDestinationChain
-        // by constructing a message with wrong dstChain.
+        // Chain C's inbox checks dstChain == block.chainid. We set block.chainid to CHAIN_C
+        // and the message says dstChain=CHAIN_B, so WrongDestinationChain fires.
         vm.chainId(CHAIN_C);
         vm.expectRevert(abi.encodeWithSelector(Inbox.WrongDestinationChain.selector, CHAIN_C, CHAIN_B));
         chainC.bridge.inbox.recvMessage(message, sigs);
@@ -241,22 +250,25 @@ contract BridgeIntegrationTest is Test {
         vm.prank(user);
         chainA.bridge.bridgeBurner.sendTo(CHAIN_B, recipient, amount);
 
-        // Deliver once
-        bytes32 nonce = _nextNonce();
+        // Build the message; derive its nonce up-front so we can assert on the revert.
+        uint256 srcSeq = _nextSeq();
         bytes memory payload = TokenMintMessage.encode(recipient, amount);
         bytes memory message = abi.encode(
             CHAIN_A,
+            address(chainA.bridge.outbox),
             address(chainA.bridge.bridgeBurner),
+            srcSeq,
             block.chainid,
             address(chainB.bridge.bridgeMinter),
-            nonce,
             payload
         );
+        bytes32 expectedNonce =
+            _deriveNonce(CHAIN_A, address(chainA.bridge.outbox), address(chainA.bridge.bridgeBurner), srcSeq);
         bytes memory sigs = _signForInbox(chainB.bridge.inbox, message);
         chainB.bridge.inbox.recvMessage(message, sigs);
 
-        // Second delivery reverts
-        vm.expectRevert(abi.encodeWithSelector(Inbox.NonceAlreadyUsed.selector, nonce));
+        // Second delivery reverts on the derived nonce.
+        vm.expectRevert(abi.encodeWithSelector(Inbox.NonceAlreadyUsed.selector, expectedNonce));
         chainB.bridge.inbox.recvMessage(message, sigs);
     }
 
@@ -266,15 +278,15 @@ contract BridgeIntegrationTest is Test {
         address unknownSender = address(0x1111);
         address recipient = address(0xBEEF);
         uint256 amount = 100e6;
-        bytes32 nonce = _nextNonce();
 
         bytes memory payload = TokenMintMessage.encode(recipient, amount);
         bytes memory message = abi.encode(
             CHAIN_A,
+            address(chainA.bridge.outbox),
             unknownSender, // not chainA.bridge.bridgeBurner
+            _nextSeq(),
             block.chainid,
             address(chainB.bridge.bridgeMinter),
-            nonce,
             payload
         );
         bytes memory sigs = _signForInbox(chainB.bridge.inbox, message);
@@ -289,22 +301,24 @@ contract BridgeIntegrationTest is Test {
         uint256 unknownChain = 999;
         address recipient = address(0xBEEF);
         uint256 amount = 100e6;
-        bytes32 nonce = _nextNonce();
 
         bytes memory payload = TokenMintMessage.encode(recipient, amount);
+        // No srcOutbox configured for `unknownChain` — the Inbox rejects before reaching
+        // the BridgeMinter's `DisallowedSender` check.
         bytes memory message = abi.encode(
             unknownChain,
-            address(chainA.bridge.bridgeBurner), // valid sender address but wrong chain
+            address(chainA.bridge.outbox), // doesn't matter — chain has no entry
+            address(chainA.bridge.bridgeBurner),
+            _nextSeq(),
             block.chainid,
             address(chainB.bridge.bridgeMinter),
-            nonce,
             payload
         );
         bytes memory sigs = _signForInbox(chainB.bridge.inbox, message);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                BridgeMinter.DisallowedSender.selector, unknownChain, address(chainA.bridge.bridgeBurner)
+                Inbox.UnknownSrcOutbox.selector, unknownChain, address(chainA.bridge.outbox), address(0)
             )
         );
         chainB.bridge.inbox.recvMessage(message, sigs);
@@ -348,18 +362,31 @@ contract BridgeIntegrationTest is Test {
     }
 
     /// @dev Cross-configure two chains so each allows the other's BridgeBurner as a sender.
+    /// Also registers the counterpart chain's Outbox in each Inbox's `srcOutboxes` map —
+    /// required so the destination Inbox can verify the source-bound nonce.
     function _crossConfigure(ChainState memory a, ChainState memory b) internal {
-        // a's minter accepts messages from b's burner
+        // a's minter accepts messages from b's burner; a's inbox knows b's outbox.
         a.bridge.bridgeMinter.setAllowedSender(b.chainId, address(b.bridge.bridgeBurner));
         a.bridge.bridgeBurner.setDstMinter(b.chainId, address(b.bridge.bridgeMinter));
+        a.bridge.inbox.setSrcOutbox(b.chainId, address(b.bridge.outbox));
 
-        // b's minter accepts messages from a's burner
+        // b's minter accepts messages from a's burner; b's inbox knows a's outbox.
         b.bridge.bridgeMinter.setAllowedSender(a.chainId, address(a.bridge.bridgeBurner));
         b.bridge.bridgeBurner.setDstMinter(a.chainId, address(a.bridge.bridgeMinter));
+        b.bridge.inbox.setSrcOutbox(a.chainId, address(a.bridge.outbox));
     }
 
-    function _nextNonce() internal returns (bytes32) {
-        return bytes32(++nonceCounter);
+    function _nextSeq() internal returns (uint256) {
+        return ++srcSeqCounter;
+    }
+
+    /// @dev Recompute the derived nonce for a manually-built message.
+    function _deriveNonce(uint256 srcChain, address srcOutbox, address srcSender, uint256 srcSeq)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(srcChain, srcOutbox, srcSender, srcSeq));
     }
 
     /// @dev Simulate the full server flow: construct message, sign, deliver.
@@ -371,20 +398,26 @@ contract BridgeIntegrationTest is Test {
         address recipient,
         uint256 amount
     ) internal {
-        _deliverMessageWithNonce(src, dst, srcSender, dstRecipient, recipient, amount, _nextNonce());
+        _deliverMessageWithSeq(src, dst, srcSender, dstRecipient, recipient, amount, _nextSeq());
     }
 
-    function _deliverMessageWithNonce(
+    /// @dev Build the wire message
+    /// `(srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload)`
+    /// and deliver it. Each invocation uses a unique `srcSeq` so the derived nonces
+    /// stay distinct.
+    function _deliverMessageWithSeq(
         ChainState memory src,
         ChainState memory dst,
         address srcSender,
         address dstRecipient,
         address recipient,
         uint256 amount,
-        bytes32 nonce
+        uint256 srcSeq
     ) internal {
         bytes memory payload = TokenMintMessage.encode(recipient, amount);
-        bytes memory message = abi.encode(src.chainId, srcSender, block.chainid, dstRecipient, nonce, payload);
+        bytes memory message = abi.encode(
+            src.chainId, address(src.bridge.outbox), srcSender, srcSeq, block.chainid, dstRecipient, payload
+        );
         bytes memory sigs = _signForInbox(dst.bridge.inbox, message);
         dst.bridge.inbox.recvMessage(message, sigs);
     }

--- a/test/bridge/BridgeBurner.t.sol
+++ b/test/bridge/BridgeBurner.t.sol
@@ -35,10 +35,15 @@ contract BridgeBurnerTest is BridgeTestBase {
         vm.prank(user);
         stablecoin.approve(address(bridge.bridgeBurner), amount);
 
-        // Expect the Outbox MessageSent event
+        // Expect the Outbox MessageSent event: it carries the per-sender srcSeq
+        // plus the derived source-bound nonce.
         bytes memory expectedPayload = TokenMintMessage.encode(recipient, amount);
+        bytes32 expectedNonce =
+            keccak256(abi.encode(block.chainid, address(bridge.outbox), address(bridge.bridgeBurner), uint256(0)));
         vm.expectEmit(true, true, true, true, address(bridge.outbox));
-        emit IOutbox.MessageSent(address(bridge.bridgeBurner), DST_CHAIN, address(0xBEEF), expectedPayload);
+        emit IOutbox.MessageSent(
+            address(bridge.bridgeBurner), DST_CHAIN, address(0xBEEF), 0, expectedNonce, expectedPayload
+        );
 
         vm.prank(user);
         bridge.bridgeBurner.sendTo(DST_CHAIN, recipient, amount);

--- a/test/bridge/BridgeDeploy.t.sol
+++ b/test/bridge/BridgeDeploy.t.sol
@@ -49,12 +49,19 @@ contract BridgeDeployTest is BridgeTestBase {
         BridgeConfig.DstMinter[] memory dstMinters = new BridgeConfig.DstMinter[](1);
         dstMinters[0] = BridgeConfig.DstMinter(42, address(0xBBBB));
 
+        // Configure the canonical Outbox for srcChain=42. Use the local Outbox
+        // since BridgeTestBase happens to deploy only one — in production this would
+        // be the counterpart chain's deterministically-deployed Outbox.
+        BridgeConfig.SrcOutbox[] memory srcOutboxes = new BridgeConfig.SrcOutbox[](1);
+        srcOutboxes[0] = BridgeConfig.SrcOutbox(42, address(bridge.outbox));
+
         BridgeConfig.Config memory config = BridgeConfig.Config({
             attestors: attestors,
             threshold: 2,
             minterAllowance: 1_000_000e6,
             allowedSenders: allowedSenders,
-            dstMinters: dstMinters
+            dstMinters: dstMinters,
+            srcOutboxes: srcOutboxes
         });
 
         vm.startPrank(ADMIN);
@@ -76,6 +83,9 @@ contract BridgeDeployTest is BridgeTestBase {
 
         // Verify dst minters
         assertEq(bridge.bridgeBurner.dstMinters(42), address(0xBBBB));
+
+        // Verify src outboxes
+        assertEq(bridge.inbox.srcOutboxes(42), address(bridge.outbox));
     }
 
     // ─── Deterministic address invariant (M-02 / #2) ─────────────────

--- a/test/bridge/BridgeTestBase.sol
+++ b/test/bridge/BridgeTestBase.sol
@@ -98,15 +98,39 @@ contract BridgeTestBase is Test {
         }
     }
 
-    /// @dev Encode a transport-level message.
+    /// @dev Encode a transport-level message using the wire format
+    /// `(srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload)`.
+    /// The Inbox recomputes the replay nonce from `(srcChain, srcOutbox, srcSender, srcSeq)`.
     function _encodeMessage(
         uint256 srcChain,
+        address srcOutbox,
         address srcSender,
+        uint256 srcSeq,
         uint256 dstChain,
         address dstRecipient,
-        bytes32 nonce,
         bytes memory payload
     ) internal pure returns (bytes memory) {
-        return abi.encode(srcChain, srcSender, dstChain, dstRecipient, nonce, payload);
+        return abi.encode(srcChain, srcOutbox, srcSender, srcSeq, dstChain, dstRecipient, payload);
+    }
+
+    /// @dev Recompute the same replay-protection nonce the Inbox derives.
+    function _deriveNonce(uint256 srcChain, address srcOutbox, address srcSender, uint256 srcSeq)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(srcChain, srcOutbox, srcSender, srcSeq));
+    }
+
+    /// @dev Register a canonical Outbox for `srcChain` on the test's Inbox.
+    /// Uses the local Outbox by default — this works in tests because there is
+    /// only one Outbox available and the Inbox treats it as opaque.
+    function _configureSrcOutbox(uint256 srcChain) internal {
+        _configureSrcOutbox(srcChain, address(bridge.outbox));
+    }
+
+    function _configureSrcOutbox(uint256 srcChain, address outbox) internal {
+        vm.prank(ADMIN);
+        bridge.inbox.setSrcOutbox(srcChain, outbox);
     }
 }

--- a/test/bridge/Inbox.t.sol
+++ b/test/bridge/Inbox.t.sol
@@ -22,6 +22,7 @@ contract MockReceiver is IMessageReceiver {
 
 contract InboxTest is BridgeTestBase {
     MockReceiver public receiver;
+    uint256 public constant SRC_CHAIN = 42;
 
     function setUp() public override {
         super.setUp();
@@ -33,6 +34,8 @@ contract InboxTest is BridgeTestBase {
         bridge.inbox.addAttestor(attestor2);
         bridge.inbox.addAttestor(attestor3);
         bridge.inbox.setThreshold(2);
+        // Register the canonical source Outbox for srcChain=42.
+        bridge.inbox.setSrcOutbox(SRC_CHAIN, address(bridge.outbox));
         vm.stopPrank();
     }
 
@@ -40,8 +43,9 @@ contract InboxTest is BridgeTestBase {
 
     function test_ValidKOfNSignatures() public {
         bytes memory payload = hex"CAFE";
-        bytes32 nonce = bytes32(uint256(1));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, payload);
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 1, block.chainid, address(receiver), payload
+        );
 
         uint256[] memory pks = new uint256[](2);
         pks[0] = ATTESTOR_PK_1;
@@ -51,14 +55,15 @@ contract InboxTest is BridgeTestBase {
         bridge.inbox.recvMessage(message, sigs);
 
         assertEq(receiver.callCount(), 1);
-        assertEq(receiver.lastSrcChain(), 42);
+        assertEq(receiver.lastSrcChain(), SRC_CHAIN);
         assertEq(receiver.lastSrcSender(), address(0xAAAA));
         assertEq(receiver.lastPayload(), payload);
     }
 
     function test_AllThreeSignatures() public {
-        bytes32 nonce = bytes32(uint256(2));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 2, block.chainid, address(receiver), hex""
+        );
 
         uint256[] memory pks = new uint256[](3);
         pks[0] = ATTESTOR_PK_1;
@@ -73,8 +78,9 @@ contract InboxTest is BridgeTestBase {
     // ─── Below threshold ─────────────────────────────────────────────
 
     function test_BelowThresholdReverts() public {
-        bytes32 nonce = bytes32(uint256(3));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 3, block.chainid, address(receiver), hex""
+        );
 
         uint256[] memory pks = new uint256[](1);
         pks[0] = ATTESTOR_PK_1;
@@ -87,8 +93,9 @@ contract InboxTest is BridgeTestBase {
     // ─── Invalid signatures ──────────────────────────────────────────
 
     function test_InvalidSignerReverts() public {
-        bytes32 nonce = bytes32(uint256(4));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 4, block.chainid, address(receiver), hex""
+        );
 
         // Use a non-attestor private key
         uint256 fakePk = 0xDEAD;
@@ -104,8 +111,9 @@ contract InboxTest is BridgeTestBase {
     // ─── Duplicate signer ────────────────────────────────────────────
 
     function test_DuplicateSignerReverts() public {
-        bytes32 nonce = bytes32(uint256(5));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 5, block.chainid, address(receiver), hex""
+        );
 
         // Sign twice with the same key
         bytes32 digest = _inboxDigest(bridge.inbox, message);
@@ -119,8 +127,11 @@ contract InboxTest is BridgeTestBase {
     // ─── Nonce replay ────────────────────────────────────────────────
 
     function test_NonceReplayReverts() public {
-        bytes32 nonce = bytes32(uint256(6));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        uint256 srcSeq = 6;
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), srcSeq, block.chainid, address(receiver), hex""
+        );
+        bytes32 expectedNonce = _deriveNonce(SRC_CHAIN, address(bridge.outbox), address(0xAAAA), srcSeq);
 
         uint256[] memory pks = new uint256[](2);
         pks[0] = ATTESTOR_PK_1;
@@ -130,8 +141,8 @@ contract InboxTest is BridgeTestBase {
         // First delivery succeeds
         bridge.inbox.recvMessage(message, sigs);
 
-        // Second delivery reverts
-        vm.expectRevert(abi.encodeWithSelector(Inbox.NonceAlreadyUsed.selector, nonce));
+        // Second delivery reverts on the derived nonce.
+        vm.expectRevert(abi.encodeWithSelector(Inbox.NonceAlreadyUsed.selector, expectedNonce));
         bridge.inbox.recvMessage(message, sigs);
     }
 
@@ -139,8 +150,8 @@ contract InboxTest is BridgeTestBase {
 
     function test_WrongDstChainReverts() public {
         uint256 wrongChain = block.chainid + 1;
-        bytes32 nonce = bytes32(uint256(7));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), wrongChain, address(receiver), nonce, hex"");
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 7, wrongChain, address(receiver), hex"");
 
         uint256[] memory pks = new uint256[](2);
         pks[0] = ATTESTOR_PK_1;
@@ -274,14 +285,134 @@ contract InboxTest is BridgeTestBase {
     // ─── Invalid signature length ────────────────────────────────────
 
     function test_InvalidSignatureLengthReverts() public {
-        bytes32 nonce = bytes32(uint256(8));
-        bytes memory message = _encodeMessage(42, address(0xAAAA), block.chainid, address(receiver), nonce, hex"");
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 8, block.chainid, address(receiver), hex""
+        );
 
         // 64 bytes (not a multiple of 65)
         bytes memory badSigs = new bytes(64);
 
         vm.expectRevert(Inbox.InvalidSignatureCount.selector);
         bridge.inbox.recvMessage(message, badSigs);
+    }
+
+    /// @notice The message does not carry a transport nonce — the Inbox derives
+    /// it from `(srcChain, srcOutbox, srcSender, srcSeq)`. Re-attesting the same
+    /// source event under a different transport nonce is not possible; any valid
+    /// attestation for the same source event produces the same key, and the Inbox
+    /// refuses the replay.
+    function test_NoncePoCBlockedByDerivedKey() public {
+        // Without source-bound nonces, "one source burn, two valid attested messages
+        // with different nonces, minting 2× amount on the destination" would be
+        // exploitable. With the derived nonce there is no separate transport nonce
+        // field: the attestors can only sign a
+        // message whose derived nonce matches the source event's `srcSeq`. Re-
+        // submitting the same (srcChain, srcOutbox, srcSender, srcSeq) tuple is
+        // exactly a replay and gets rejected by `usedNonces`.
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 99, block.chainid, address(receiver), hex"FEED"
+        );
+        bytes32 expectedNonce = _deriveNonce(SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 99);
+
+        uint256[] memory pks = new uint256[](2);
+        pks[0] = ATTESTOR_PK_1;
+        pks[1] = ATTESTOR_PK_2;
+        bytes memory sigs = _signMessage(bridge.inbox, message, pks);
+
+        bridge.inbox.recvMessage(message, sigs);
+        assertEq(receiver.callCount(), 1);
+
+        // Replay with the same tuple ⇒ same derived nonce ⇒ rejected.
+        vm.expectRevert(abi.encodeWithSelector(Inbox.NonceAlreadyUsed.selector, expectedNonce));
+        bridge.inbox.recvMessage(message, sigs);
+    }
+
+    /// @notice An attestor quorum cannot bypass the source-event binding by claiming
+    /// the message came from a stranger Outbox: `srcOutboxes[srcChain]` is the
+    /// canonical Outbox, and the Inbox refuses anything else.
+    function test_StrangerSrcOutboxRejected() public {
+        address strangerOutbox = address(0xBEEF);
+        bytes memory message =
+            _encodeMessage(SRC_CHAIN, strangerOutbox, address(0xAAAA), 1, block.chainid, address(receiver), hex"");
+
+        uint256[] memory pks = new uint256[](2);
+        pks[0] = ATTESTOR_PK_1;
+        pks[1] = ATTESTOR_PK_2;
+        bytes memory sigs = _signMessage(bridge.inbox, message, pks);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Inbox.UnknownSrcOutbox.selector, SRC_CHAIN, strangerOutbox, address(bridge.outbox))
+        );
+        bridge.inbox.recvMessage(message, sigs);
+    }
+
+    /// @notice A message whose `srcChain` has no configured Outbox is rejected.
+    function test_UnconfiguredSrcChainRejected() public {
+        uint256 unconfiguredChain = 7777;
+        bytes memory message = _encodeMessage(
+            unconfiguredChain, address(bridge.outbox), address(0xAAAA), 1, block.chainid, address(receiver), hex""
+        );
+
+        uint256[] memory pks = new uint256[](2);
+        pks[0] = ATTESTOR_PK_1;
+        pks[1] = ATTESTOR_PK_2;
+        bytes memory sigs = _signMessage(bridge.inbox, message, pks);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Inbox.UnknownSrcOutbox.selector, unconfiguredChain, address(bridge.outbox), address(0)
+            )
+        );
+        bridge.inbox.recvMessage(message, sigs);
+    }
+
+    /// @notice `setSrcOutbox` refuses to overwrite a non-zero entry directly — the
+    /// operator must explicitly clear first. Prevents the silent "swap Outbox while
+    /// messages are in flight" footgun.
+    function test_SetSrcOutboxRefusesSilentOverwrite() public {
+        // SRC_CHAIN was already wired in setUp.
+        address newOutbox = address(bridge.outbox); // shape-valid candidate
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Inbox.SrcOutboxAlreadySet.selector, SRC_CHAIN, address(bridge.outbox)));
+        bridge.inbox.setSrcOutbox(SRC_CHAIN, newOutbox);
+    }
+
+    /// @notice `setSrcOutbox(srcChain, address(0))` clears the route. Pause-and-drain
+    /// is the operator-side prerequisite to swapping Outboxes.
+    function test_SetSrcOutboxAllowsClear() public {
+        vm.prank(ADMIN);
+        bridge.inbox.setSrcOutbox(SRC_CHAIN, address(0));
+        assertEq(bridge.inbox.srcOutboxes(SRC_CHAIN), address(0));
+
+        // After clearing, the chain has no canonical Outbox and recvMessage rejects.
+        bytes memory message = _encodeMessage(
+            SRC_CHAIN, address(bridge.outbox), address(0xAAAA), 1, block.chainid, address(receiver), hex""
+        );
+        uint256[] memory pks = new uint256[](2);
+        pks[0] = ATTESTOR_PK_1;
+        pks[1] = ATTESTOR_PK_2;
+        bytes memory sigs = _signMessage(bridge.inbox, message, pks);
+        vm.expectRevert();
+        bridge.inbox.recvMessage(message, sigs);
+    }
+
+    /// @notice `setSrcOutbox` validates candidates the same way `BridgeBurner.setOutbox` does:
+    /// zero-check + bytecode check + ERC-165 advertisement.
+    function test_SetSrcOutboxRejectsEoa() public {
+        address eoa = address(0xCAFEBABE);
+        vm.prank(ADMIN);
+        // No previous entry → goes through validation; EOA has no code.
+        bridge.inbox.setSrcOutbox(123, address(0)); // ensure clear
+        vm.prank(ADMIN);
+        vm.expectRevert(abi.encodeWithSelector(Inbox.InvalidOutbox.selector, eoa));
+        bridge.inbox.setSrcOutbox(123, eoa);
+    }
+
+    function test_OnlyOwnerCanSetSrcOutbox() public {
+        address nonOwner = address(0x9999);
+        vm.prank(nonOwner);
+        vm.expectRevert();
+        bridge.inbox.setSrcOutbox(123, address(0xBEEF));
     }
 
     // ─── Selector collision safety ──────────

--- a/test/bridge/Outbox.t.sol
+++ b/test/bridge/Outbox.t.sol
@@ -5,16 +5,59 @@ import {BridgeTestBase} from "./BridgeTestBase.sol";
 import {IOutbox} from "../../src/bridge/interfaces/IOutbox.sol";
 
 contract OutboxTest is BridgeTestBase {
-    function test_SendMessageEmitsEvent() public {
+    function test_SendMessageEmitsEventWithDerivedNonce() public {
         address sender = address(0xCAFE);
         uint256 dstChain = 137;
         address dstRecipient = address(0xBEEF);
         bytes memory payload = hex"1234";
 
+        // First message from `sender` consumes srcSeq=0; nonce derives from
+        // (this chain id, this outbox addr, sender, 0). Must match the Outbox
+        // formula exactly.
+        bytes32 expectedNonce = keccak256(abi.encode(block.chainid, address(bridge.outbox), sender, uint256(0)));
+
         vm.prank(sender);
         vm.expectEmit(true, true, true, true);
-        emit IOutbox.MessageSent(sender, dstChain, dstRecipient, payload);
+        emit IOutbox.MessageSent(sender, dstChain, dstRecipient, 0, expectedNonce, payload);
         bridge.outbox.sendMessage(dstChain, dstRecipient, payload);
+
+        // Counter advanced.
+        assertEq(bridge.outbox.nextSeq(sender), 1);
+    }
+
+    /// @notice Each sender has its own monotonically-increasing counter. Sending from
+    /// sender A does not affect sender B's sequence.
+    function test_PerSenderCounterIndependence() public {
+        address a = address(0xA);
+        address b = address(0xB);
+
+        vm.prank(a);
+        bridge.outbox.sendMessage(1, address(0xBEEF), hex"01");
+        vm.prank(a);
+        bridge.outbox.sendMessage(1, address(0xBEEF), hex"02");
+        vm.prank(b);
+        bridge.outbox.sendMessage(1, address(0xBEEF), hex"03");
+
+        assertEq(bridge.outbox.nextSeq(a), 2);
+        assertEq(bridge.outbox.nextSeq(b), 1);
+    }
+
+    /// @notice Re-sending the same logical content from the same sender yields a
+    /// DIFFERENT nonce on every call, because the per-sender counter increments.
+    /// This is what makes attestor re-attestation harmless: the same source event
+    /// always derives the same nonce, but a *new* source event derives a *new* one.
+    function test_NonceChangesAcrossSequentialSends() public {
+        address sender = address(0xCAFE);
+
+        vm.prank(sender);
+        (uint256 seq0, bytes32 nonce0) = bridge.outbox.sendMessage(1, address(0xBEEF), hex"01");
+
+        vm.prank(sender);
+        (uint256 seq1, bytes32 nonce1) = bridge.outbox.sendMessage(1, address(0xBEEF), hex"02");
+
+        assertEq(seq0, 0);
+        assertEq(seq1, 1);
+        assertTrue(nonce0 != nonce1);
     }
 
     function test_AnyoneCanSendMessage() public {


### PR DESCRIPTION
**Problem:** The previous Inbox accepted any 32-byte transport nonce the attestor quorum chose to sign over, with no on-chain link to a unique source-chain event. 

**Fix.** Derive the replay-protection nonce on-chain from a tuple identifying the source event uniquely: `nonce = keccak256(abi.encode(srcChain, srcOutbox, srcSender, srcSeq))`. The Outbox gains a per-sender monotonic `nextSeq[msg.sender]` counter and emits `MessageSent(sender, dstChain, dstRecipient, srcSeq, nonce, payload)`.